### PR TITLE
Fixed bugs in calculation process

### DIFF
--- a/src/Profitocracy.Core/Domain/Model/Profiles/Profile.cs
+++ b/src/Profitocracy.Core/Domain/Model/Profiles/Profile.cs
@@ -196,6 +196,11 @@ public class Profile : AggregateRoot<Guid>
 		}
 		else
 		{
+			if (transaction.SpendingType != SpendingType.Saved && transaction.Timestamp < BillingPeriod.DateFrom)
+			{
+				return;
+			}
+			
 			HandleExpenseTransaction(transaction, currentDate);
 		}
 	}
@@ -245,7 +250,7 @@ public class Profile : AggregateRoot<Guid>
 				HandleSecondarySpendingTransaction(transaction);
 				break;
 			case SpendingType.Saved:
-				HandleSavingSpendingTransaction(transaction);
+				HandleSavingSpendingTransaction(transaction, currentDate);
 				break;
 			default:
 				throw new ArgumentOutOfRangeException(nameof(transaction.SpendingType));
@@ -267,10 +272,14 @@ public class Profile : AggregateRoot<Guid>
 		Expenses.Secondary.ActualAmount += transaction.Amount;
 	}
 	
-	private void HandleSavingSpendingTransaction(Transaction transaction)
+	private void HandleSavingSpendingTransaction(Transaction transaction, DateTime currentDate)
 	{
+		if (transaction.Timestamp.Month == currentDate.Month)
+		{
+			Expenses.Saved.ActualAmount = transaction.Amount;	
+		}
+		
 		SavedBalance += transaction.Amount;
-		Expenses.Saved.ActualAmount = transaction.Amount;
 	}
 
 	private void HandleCategoryTransaction(Transaction transaction)

--- a/src/Profitocracy.Core/Domain/Model/Profiles/Profile.cs
+++ b/src/Profitocracy.Core/Domain/Model/Profiles/Profile.cs
@@ -65,11 +65,22 @@ public class Profile : AggregateRoot<Guid>
 
 		BillingPeriod = new TimePeriod
 		{
-			DateFrom = new DateTime(StartDate.Timestamp.Year, StartDate.Timestamp.Month, 1),
+			DateFrom = new DateTime(
+				StartDate.Timestamp.Year, 
+				StartDate.Timestamp.Month, 
+				day: 1,
+				hour: 0,
+				minute: 0,
+				second: 0,
+				millisecond: 0),
 			DateTo = new DateTime(
 				StartDate.Timestamp.Year,
 				StartDate.Timestamp.Month,
-				day: DateTime.DaysInMonth(StartDate.Timestamp.Year, StartDate.Timestamp.Month))
+				day: DateTime.DaysInMonth(StartDate.Timestamp.Year, StartDate.Timestamp.Month),
+				hour: 23,
+				minute: 59,
+				second: 59,
+				millisecond: 999)
 		};
 	}
 

--- a/src/Profitocracy.Core/Domain/Model/Profiles/Profile.cs
+++ b/src/Profitocracy.Core/Domain/Model/Profiles/Profile.cs
@@ -18,7 +18,7 @@ public class Profile : AggregateRoot<Guid>
 		string name,
 		AnchorDate startDate,
 		decimal savedBalance,
-		List<ProfileCategory> categoriesBalances,
+		List<ProfileCategory> categoriesExpenses,
 		ProfileSettings settings,
 		bool isCurrent) : base(id)
 	{
@@ -26,7 +26,7 @@ public class Profile : AggregateRoot<Guid>
 		StartDate = startDate;
 		Balance = StartDate.InitialBalance;
 		SavedBalance = savedBalance;
-		CategoriesBalances = categoriesBalances;
+		CategoriesExpenses = categoriesExpenses;
 		Settings = settings;
 		IsCurrent = isCurrent;
 		Expenses = new ProfileExpenses
@@ -74,7 +74,7 @@ public class Profile : AggregateRoot<Guid>
 	}
 
 	/// <summary>
-	/// Does profile need to be updated and saved
+	/// Is billing period of profile new
 	/// </summary>
 	public bool IsNewPeriod { get; private set; }
 	
@@ -111,7 +111,7 @@ public class Profile : AggregateRoot<Guid>
 	/// <summary>
 	/// Result of expenses calculations for every category
 	/// </summary>
-	public List<ProfileCategory> CategoriesBalances { get; }
+	public List<ProfileCategory> CategoriesExpenses { get; }
 	
 	/// <summary>
 	/// Profile settings
@@ -165,7 +165,7 @@ public class Profile : AggregateRoot<Guid>
 	/// <param name="categories">List of categories to add to profile</param>
 	public void AddCategories(IEnumerable<ProfileCategory> categories)
 	{
-		CategoriesBalances.AddRange(categories);
+		CategoriesExpenses.AddRange(categories);
 	}
 	
 	private void HandleTransaction(Transaction transaction, DateTime currentDate)
@@ -254,7 +254,8 @@ public class Profile : AggregateRoot<Guid>
 
 	private void HandleCategoryTransaction(Transaction transaction)
 	{
-		var category = CategoriesBalances.Find(c => c.Id.Equals(transaction.Category!.Id));
+		var category = CategoriesExpenses
+			.Find(c => c.Id.Equals(transaction.Category!.Id));
 
 		if (category is null)
 		{

--- a/src/Profitocracy.Core/Domain/Model/Profiles/Profile.cs
+++ b/src/Profitocracy.Core/Domain/Model/Profiles/Profile.cs
@@ -82,6 +82,8 @@ public class Profile : AggregateRoot<Guid>
 				second: 59,
 				millisecond: 999)
 		};
+
+		_todayInitialBalance = Balance;
 	}
 
 	/// <summary>
@@ -134,6 +136,13 @@ public class Profile : AggregateRoot<Guid>
 	/// </summary>
 	public bool IsCurrent { get; }
 
+	/// <summary>
+	/// This field is used to correctly calculate money for today.
+	/// Without this field we will see decreasing amount of
+	/// PlannedAmount of DailyFromActualBalance
+	/// </summary>
+	private decimal _todayInitialBalance;
+	
 	/// <summary>
 	/// Process transaction and
 	/// project results in profile
@@ -196,11 +205,12 @@ public class Profile : AggregateRoot<Guid>
 		var daysInInitialPeriod = BillingPeriod.DateTo.Day - BillingPeriod.DateFrom.Day + 1;
 		var daysInActualPeriod = BillingPeriod.DateTo.Day - currentDate.Day + 1;
 		
+		// Used to prevent division by zero
 		daysInInitialPeriod = daysInInitialPeriod == 0 ? 1 : daysInInitialPeriod;
 		daysInActualPeriod = daysInActualPeriod == 0 ? 1 : daysInActualPeriod;
 
 		Expenses.TotalBalance.PlannedAmount += StartDate.InitialBalance;
-		Expenses.DailyFromActualBalance.PlannedAmount = Balance / daysInActualPeriod;
+		Expenses.DailyFromActualBalance.PlannedAmount = _todayInitialBalance / daysInActualPeriod;
 		Expenses.DailyFromInitialBalance.PlannedAmount = Expenses.TotalBalance.PlannedAmount / daysInInitialPeriod;
 		
 		Expenses.Main.PlannedAmount = Expenses.TotalBalance.PlannedAmount * 0.5m;

--- a/src/Profitocracy.Core/Domain/Model/Profiles/ValueObjects/ProfileExpenses.cs
+++ b/src/Profitocracy.Core/Domain/Model/Profiles/ValueObjects/ProfileExpenses.cs
@@ -9,30 +9,30 @@ public class ProfileExpenses
 	/// <summary>
 	/// Total amount of expenses
 	/// </summary>
-	public required ProfileExpense TotalBalance { get; set; }
+	public required ProfileExpense TotalBalance { get; init; }
 	
 	/// <summary>
 	/// Daily amounts from actual profile balance
 	/// </summary>
-	public required ProfileExpense DailyFromActualBalance { get; set; }
+	public required ProfileExpense DailyFromActualBalance { get; init; }
 	
 	/// <summary>
 	/// Daily amounts from initial profile balance
 	/// </summary>
-	public required ProfileExpense DailyFromInitialBalance { get; set; }
+	public required ProfileExpense DailyFromInitialBalance { get; init; }
 	
 	/// <summary>
 	/// Main expenses amount
 	/// </summary>
-	public required ProfileExpense Main { get; set; }
+	public required ProfileExpense Main { get; init; }
 	
 	/// <summary>
 	/// Secondary expenses amount
 	/// </summary>
-	public required ProfileExpense Secondary { get; set; }
+	public required ProfileExpense Secondary { get; init; }
 	
 	/// <summary>
 	/// Saved amount
 	/// </summary>
-	public required ProfileExpense Saved { get; set; }
+	public required ProfileExpense Saved { get; init; }
 }

--- a/src/Profitocracy.Core/Domain/Services/ProfileService.cs
+++ b/src/Profitocracy.Core/Domain/Services/ProfileService.cs
@@ -33,7 +33,7 @@ internal class ProfileService : IProfileService
 		
 		var transactions = await _transactionRepository.GetForPeriod(
 			profile.Id, 
-			profile.BillingPeriod.DateFrom, 
+			profile.BillingPeriod.DateFrom,
 			profile.BillingPeriod.DateTo);
 		
 		var categories = await _categoryRepository.GetAllByProfileId(profile.Id);

--- a/src/Profitocracy.Infrastructure/Persistence/Sqlite/Mappers/ProfileMapper.cs
+++ b/src/Profitocracy.Infrastructure/Persistence/Sqlite/Mappers/ProfileMapper.cs
@@ -35,7 +35,7 @@ internal class ProfileMapper : IInfrastructureMapper<Profile, ProfileModel>
 
 	public ProfileModel MapToModel(Profile entity)
 	{
-		var categories = entity.CategoriesBalances
+		var categories = entity.CategoriesExpenses
 			.Select(c => new ProfileCategoryModel
 			{
 				CategoryId = c.Id,

--- a/src/Profitocracy.Mobile/Profitocracy.Mobile.csproj
+++ b/src/Profitocracy.Mobile/Profitocracy.Mobile.csproj
@@ -29,8 +29,8 @@
         <ApplicationId>com.krawmire.profitocracy</ApplicationId>
 
         <!-- Versions -->
-        <ApplicationDisplayVersion>1.3.0</ApplicationDisplayVersion>
-        <ApplicationVersion>14</ApplicationVersion>
+        <ApplicationDisplayVersion>1.3.1</ApplicationDisplayVersion>
+        <ApplicationVersion>15</ApplicationVersion>
 
         <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">12.2</SupportedOSPlatformVersion>
         <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">15.0</SupportedOSPlatformVersion>

--- a/src/Profitocracy.Mobile/ViewModels/Categories/ExpenseCategoriesSettingsPageViewModel.cs
+++ b/src/Profitocracy.Mobile/ViewModels/Categories/ExpenseCategoriesSettingsPageViewModel.cs
@@ -20,7 +20,7 @@ public class ExpenseCategoriesSettingsPageViewModel : BaseNotifyObject
 
     public readonly ObservableCollection<CategoryModel> Categories = [];
 
-    public async void Initialize()
+    public async Task Initialize()
     {
         var profileId = await _profileRepository.GetCurrentProfileId();
 

--- a/src/Profitocracy.Mobile/ViewModels/Setup/SetupPageViewModel.cs
+++ b/src/Profitocracy.Mobile/ViewModels/Setup/SetupPageViewModel.cs
@@ -29,7 +29,7 @@ public class SetupPageViewModel : BaseNotifyObject
         set => SetProperty(ref _initialBalance, value);
     }
 
-    public async void CreateFirstProfile()
+    public async Task CreateFirstProfile()
     {
         _initialBalance = _initialBalance.Replace(
             ",", 

--- a/src/Profitocracy.Mobile/ViewModels/Transactions/TransactionsPageViewModel.cs
+++ b/src/Profitocracy.Mobile/ViewModels/Transactions/TransactionsPageViewModel.cs
@@ -46,7 +46,16 @@ public class TransactionsPageViewModel : BaseNotifyObject
         get => _toDate;
         set
         {
-            SetProperty(ref _toDate, value);
+            var newValue = new DateTime(
+                value.Year, 
+                value.Month, 
+                value.Day,
+                hour: 0,
+                minute: 0,
+                second: 0,
+                millisecond: 0);
+            
+            SetProperty(ref _toDate, newValue);
             _ = InitializeTransactions();
         }
     }

--- a/src/Profitocracy.Mobile/ViewModels/Transactions/TransactionsPageViewModel.cs
+++ b/src/Profitocracy.Mobile/ViewModels/Transactions/TransactionsPageViewModel.cs
@@ -37,7 +37,7 @@ public class TransactionsPageViewModel : BaseNotifyObject
         set
         {
             SetProperty(ref _fromDate, value);
-            InitializeTransactions();
+            _ = InitializeTransactions();
         }
     }
     
@@ -47,7 +47,7 @@ public class TransactionsPageViewModel : BaseNotifyObject
         set
         {
             SetProperty(ref _toDate, value);
-            InitializeTransactions();
+            _ = InitializeTransactions();
         }
     }
     
@@ -66,7 +66,7 @@ public class TransactionsPageViewModel : BaseNotifyObject
             return;
         }
         
-        InitializeTransactions();
+        await InitializeTransactions();
     }
     
     public async Task DeleteTransaction(Guid transactionId)
@@ -76,7 +76,7 @@ public class TransactionsPageViewModel : BaseNotifyObject
         Transactions.Remove(Transactions.Single(t => t.Id == deletedId));
     }
 
-    private async void InitializeTransactions()
+    private async Task InitializeTransactions()
     {
         if (_profileId is null)
         {

--- a/src/Profitocracy.Mobile/Views/Home/HomePage.xaml
+++ b/src/Profitocracy.Mobile/Views/Home/HomePage.xaml
@@ -8,210 +8,213 @@
              Title="{x:Static resx:AppResources.Home}"
              BackgroundColor="{AppThemeBinding Light={StaticResource LightBackground}, Dark={StaticResource DarkBackground}}"
              NavigatedTo="HomePage_OnNavigated">
-    <ScrollView VerticalScrollBarVisibility="Never">
-        <VerticalStackLayout Padding="8, 16">
-            
-            <Border Style="{StaticResource ProfileExpenseCard}">
-                <Border.Shadow>
-                    <Shadow Brush="{AppThemeBinding Light={StaticResource Gray300}, Dark={StaticResource Gray950}}"
-                            Offset="0,8"
-                            Radius="16"
-                            Opacity="0.9" />
-                </Border.Shadow>
-                <StackLayout>
-                    <FlexLayout JustifyContent="SpaceBetween">
-                        <Label Style="{StaticResource ProfileExpenseCardTitle}"
-                               Text="{Binding ProfileName}"/>
-                        <Label Style="{StaticResource ProfileExpenseCardPeriod}"
-                               VerticalTextAlignment="End">
-                            <Label.Text>
-                                <MultiBinding StringFormat="{}{0} - {1}">
-                                    <Binding Path="DateFrom"/>
-                                    <Binding Path="DateTo"/>
-                                </MultiBinding>
-                            </Label.Text>
-                        </Label>
-                    </FlexLayout>
-                    <FlexLayout JustifyContent="SpaceBetween"
-                                Margin="0, 16, 0, 0">
-                        <Label Style="{StaticResource ProfileExpenseCardSubtitle}"
-                               Text="{x:Static resx:AppResources.Balance}"/>
-                        <Label Style="{StaticResource ProfileExpenseCardBalance}"
-                               Text="{Binding Balance}"/>
-                    </FlexLayout>
-                    <StackLayout Margin="0, 16, 0, 0">
-                        <ProgressBar Style="{StaticResource ProfileExpenseCardProgressBar}" 
-                                     Progress="{Binding TotalBalanceRatio}"/>
+    <RefreshView IsRefreshing="{Binding IsRefreshing}"
+                 Command="{Binding RefreshCommand}">
+        <ScrollView VerticalScrollBarVisibility="Never">
+            <VerticalStackLayout Padding="8, 16">
+                
+                <Border Style="{StaticResource ProfileExpenseCard}">
+                    <Border.Shadow>
+                        <Shadow Brush="{AppThemeBinding Light={StaticResource Gray300}, Dark={StaticResource Gray950}}"
+                                Offset="0,8"
+                                Radius="16"
+                                Opacity="0.9" />
+                    </Border.Shadow>
+                    <StackLayout>
                         <FlexLayout JustifyContent="SpaceBetween">
-                            <Label Style="{StaticResource ProfileExpenseCardProgressValue}" 
-                                   Text="{Binding TotalActualAmount}"/>
-                            <Label Style="{StaticResource ProfileExpenseCardProgressValue}" 
-                                   Text="{Binding TotalPlannedAmount}" />
+                            <Label Style="{StaticResource ProfileExpenseCardTitle}"
+                                   Text="{Binding ProfileName}"/>
+                            <Label Style="{StaticResource ProfileExpenseCardPeriod}"
+                                   VerticalTextAlignment="End">
+                                <Label.Text>
+                                    <MultiBinding StringFormat="{}{0} - {1}">
+                                        <Binding Path="DateFrom"/>
+                                        <Binding Path="DateTo"/>
+                                    </MultiBinding>
+                                </Label.Text>
+                            </Label>
+                        </FlexLayout>
+                        <FlexLayout JustifyContent="SpaceBetween"
+                                    Margin="0, 16, 0, 0">
+                            <Label Style="{StaticResource ProfileExpenseCardSubtitle}"
+                                   Text="{x:Static resx:AppResources.Balance}"/>
+                            <Label Style="{StaticResource ProfileExpenseCardBalance}"
+                                   Text="{Binding Balance}"/>
+                        </FlexLayout>
+                        <StackLayout Margin="0, 16, 0, 0">
+                            <ProgressBar Style="{StaticResource ProfileExpenseCardProgressBar}" 
+                                         Progress="{Binding TotalBalanceRatio}"/>
+                            <FlexLayout JustifyContent="SpaceBetween">
+                                <Label Style="{StaticResource ProfileExpenseCardProgressValue}" 
+                                       Text="{Binding TotalActualAmount}"/>
+                                <Label Style="{StaticResource ProfileExpenseCardProgressValue}" 
+                                       Text="{Binding TotalPlannedAmount}" />
+                            </FlexLayout>
+                        </StackLayout>
+                        <FlexLayout JustifyContent="SpaceBetween"
+                                    Margin="0, 16, 0, 0">
+                            <Label Style="{StaticResource ProfileExpenseCardSubtitle}" 
+                                   Text="{x:Static resx:AppResources.SavedBalance}" />
+                            <Label Style="{StaticResource ProfileExpenseCardBalance}"
+                                   Text="{Binding TotalSavedAmount}" />
                         </FlexLayout>
                     </StackLayout>
-                    <FlexLayout JustifyContent="SpaceBetween"
-                                Margin="0, 16, 0, 0">
-                        <Label Style="{StaticResource ProfileExpenseCardSubtitle}" 
-                               Text="{x:Static resx:AppResources.SavedBalance}" />
-                        <Label Style="{StaticResource ProfileExpenseCardBalance}"
-                               Text="{Binding TotalSavedAmount}" />
-                    </FlexLayout>
-                </StackLayout>
-            </Border>
-            
-            <Border Style="{StaticResource ExpenseCard}"
-                    Margin="0, 16, 0, 0">
-                <StackLayout>
-                    <Label Style="{StaticResource ExpenseCardTitle}"
-                           Text="{x:Static resx:AppResources.DailyAmounts}"/>
-                    <Grid Margin="0, 16, 0, 0">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition />
-                            <ColumnDefinition />
-                        </Grid.ColumnDefinitions>
-                        <StackLayout Grid.Column="0"
-                                     Padding="0, 0, 8, 0">
+                </Border>
+                
+                <Border Style="{StaticResource ExpenseCard}"
+                        Margin="0, 16, 0, 0">
+                    <StackLayout>
+                        <Label Style="{StaticResource ExpenseCardTitle}"
+                               Text="{x:Static resx:AppResources.DailyAmounts}"/>
+                        <Grid Margin="0, 16, 0, 0">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition />
+                                <ColumnDefinition />
+                            </Grid.ColumnDefinitions>
+                            <StackLayout Grid.Column="0"
+                                         Padding="0, 0, 8, 0">
+                                <Label Style="{StaticResource ExpenseCardSubtitle}"
+                                       Text="{x:Static resx:AppResources.FromInitialBalance}"/>
+                                <ProgressBar Style="{StaticResource ExpenseCardProgressBar}"
+                                             Margin="0,8,0,0"
+                                             Progress="{Binding DailyFromInitialRatio}"/>
+                                <FlexLayout JustifyContent="SpaceBetween">
+                                    <Label Style="{StaticResource ExpenseCardProgressValue}"
+                                           Text="{Binding DailyFromInitialActualAmount}"/>
+                                    <Label Style="{StaticResource ExpenseCardProgressValue}"
+                                           Text="{Binding DailyFromInitialPlannedAmount}" />
+                                </FlexLayout>
+                            </StackLayout>
+                            <StackLayout Grid.Column="1"
+                                         Padding="8, 0, 0, 0">
+                                <Label Style="{StaticResource ExpenseCardSubtitle}"
+                                       Text="{x:Static resx:AppResources.FromActualBalance}"/>
+                                <ProgressBar Style="{StaticResource ExpenseCardProgressBar}"
+                                             Margin="0,8,0,0"
+                                             Progress="{Binding DailyFromActualRatio}"/>
+                                <FlexLayout JustifyContent="SpaceBetween">
+                                    <Label Style="{StaticResource ExpenseCardProgressValue}"
+                                           Text="{Binding DailyFromActualActualAmount}"/>
+                                    <Label Style="{StaticResource ExpenseCardProgressValue}"
+                                           Text="{Binding DailyFromActualPlannedAmount}" />
+                                </FlexLayout>
+                            </StackLayout>
+                        </Grid>
+                    </StackLayout>
+                </Border>
+                
+                <Border Style="{StaticResource ExpenseCard}"
+                        Margin="0, 16, 0, 0">
+                    <StackLayout>
+                        <Label Style="{StaticResource ExpenseCardTitle}"
+                               Text="{x:Static resx:AppResources.SpendingTypes}"/>
+                            
+                        <StackLayout x:Name="MainExpenses"
+                                     Margin="0,16,0,0">
+                            <StackLayout.GestureRecognizers>
+                                <TapGestureRecognizer Tapped="MainSpendingTypeLayout_OnTapped" />
+                            </StackLayout.GestureRecognizers>
                             <Label Style="{StaticResource ExpenseCardSubtitle}"
-                                   Text="{x:Static resx:AppResources.FromInitialBalance}"/>
+                                   Text="{x:Static resx:AppResources.Main}"/>
                             <ProgressBar Style="{StaticResource ExpenseCardProgressBar}"
                                          Margin="0,8,0,0"
-                                         Progress="{Binding DailyFromInitialRatio}"/>
+                                         Progress="{Binding MainExpensesRatio}"/>
                             <FlexLayout JustifyContent="SpaceBetween">
                                 <Label Style="{StaticResource ExpenseCardProgressValue}"
-                                       Text="{Binding DailyFromInitialActualAmount}"/>
+                                       Text="{Binding MainActualAmount}"/>
                                 <Label Style="{StaticResource ExpenseCardProgressValue}"
-                                       Text="{Binding DailyFromInitialPlannedAmount}" />
+                                       Text="{Binding MainPlannedAmount}" />
                             </FlexLayout>
                         </StackLayout>
-                        <StackLayout Grid.Column="1"
-                                     Padding="8, 0, 0, 0">
-                            <Label Style="{StaticResource ExpenseCardSubtitle}"
-                                   Text="{x:Static resx:AppResources.FromActualBalance}"/>
-                            <ProgressBar Style="{StaticResource ExpenseCardProgressBar}"
-                                         Margin="0,8,0,0"
-                                         Progress="{Binding DailyFromActualRatio}"/>
-                            <FlexLayout JustifyContent="SpaceBetween">
-                                <Label Style="{StaticResource ExpenseCardProgressValue}"
-                                       Text="{Binding DailyFromActualActualAmount}"/>
-                                <Label Style="{StaticResource ExpenseCardProgressValue}"
-                                       Text="{Binding DailyFromActualPlannedAmount}" />
-                            </FlexLayout>
-                        </StackLayout>
-                    </Grid>
-                </StackLayout>
-            </Border>
-            
-            <Border Style="{StaticResource ExpenseCard}"
-                    Margin="0, 16, 0, 0">
-                <StackLayout>
-                    <Label Style="{StaticResource ExpenseCardTitle}"
-                           Text="{x:Static resx:AppResources.SpendingTypes}"/>
                         
-                    <StackLayout x:Name="MainExpenses"
-                                 Margin="0,16,0,0">
-                        <StackLayout.GestureRecognizers>
-                            <TapGestureRecognizer Tapped="MainSpendingTypeLayout_OnTapped" />
-                        </StackLayout.GestureRecognizers>
-                        <Label Style="{StaticResource ExpenseCardSubtitle}"
-                               Text="{x:Static resx:AppResources.Main}"/>
-                        <ProgressBar Style="{StaticResource ExpenseCardProgressBar}"
-                                     Margin="0,8,0,0"
-                                     Progress="{Binding MainExpensesRatio}"/>
-                        <FlexLayout JustifyContent="SpaceBetween">
-                            <Label Style="{StaticResource ExpenseCardProgressValue}"
-                                   Text="{Binding MainActualAmount}"/>
-                            <Label Style="{StaticResource ExpenseCardProgressValue}"
-                                   Text="{Binding MainPlannedAmount}" />
-                        </FlexLayout>
+                        <StackLayout x:Name="SecondaryExpenses"
+                                     Margin="0,16,0,0">
+                            <StackLayout.GestureRecognizers>
+                                <TapGestureRecognizer Tapped="SecondarySpendingTypeLayout_OnTapped" />
+                            </StackLayout.GestureRecognizers>
+                            <Label Style="{StaticResource ExpenseCardSubtitle}"
+                                   Text="{x:Static resx:AppResources.Secondary}"/>
+                            <ProgressBar Style="{StaticResource ExpenseCardProgressBar}"
+                                         Margin="0,8,0,0"
+                                         Progress="{Binding SecondaryExpensesRatio}"/>
+                            <FlexLayout JustifyContent="SpaceBetween">
+                                <Label Style="{StaticResource ExpenseCardProgressValue}"
+                                       Text="{Binding SecondaryActualAmount}"/>
+                                <Label Style="{StaticResource ExpenseCardProgressValue}"
+                                       Text="{Binding SecondaryPlannedAmount}" />
+                            </FlexLayout>
+                        </StackLayout>
+                        
+                        <StackLayout x:Name="SavedExpenses" 
+                                     Margin="0,16,0,0">
+                            <StackLayout.GestureRecognizers>
+                                <TapGestureRecognizer Tapped="SavedSpendingTypeLayout_OnTapped" />
+                            </StackLayout.GestureRecognizers>
+                            <Label Style="{StaticResource ExpenseCardSubtitle}"
+                                   Text="{x:Static resx:AppResources.Saved}"/>
+                            <ProgressBar Style="{StaticResource ExpenseCardProgressBar}"
+                                         Margin="0,8,0,0"
+                                         Progress="{Binding SavedRatio}"/>
+                            <FlexLayout JustifyContent="SpaceBetween">
+                                <Label Style="{StaticResource ExpenseCardProgressValue}"
+                                       Text="{Binding SavedActualAmount}"/>
+                                <Label Style="{StaticResource ExpenseCardProgressValue}"
+                                       Text="{Binding SavedPlannedAmount}" />
+                            </FlexLayout>
+                        </StackLayout>
                     </StackLayout>
-                    
-                    <StackLayout x:Name="SecondaryExpenses"
-                                 Margin="0,16,0,0">
-                        <StackLayout.GestureRecognizers>
-                            <TapGestureRecognizer Tapped="SecondarySpendingTypeLayout_OnTapped" />
-                        </StackLayout.GestureRecognizers>
-                        <Label Style="{StaticResource ExpenseCardSubtitle}"
-                               Text="{x:Static resx:AppResources.Secondary}"/>
-                        <ProgressBar Style="{StaticResource ExpenseCardProgressBar}"
-                                     Margin="0,8,0,0"
-                                     Progress="{Binding SecondaryExpensesRatio}"/>
-                        <FlexLayout JustifyContent="SpaceBetween">
-                            <Label Style="{StaticResource ExpenseCardProgressValue}"
-                                   Text="{Binding SecondaryActualAmount}"/>
-                            <Label Style="{StaticResource ExpenseCardProgressValue}"
-                                   Text="{Binding SecondaryPlannedAmount}" />
-                        </FlexLayout>
-                    </StackLayout>
-                    
-                    <StackLayout x:Name="SavedExpenses" 
-                                 Margin="0,16,0,0">
-                        <StackLayout.GestureRecognizers>
-                            <TapGestureRecognizer Tapped="SavedSpendingTypeLayout_OnTapped" />
-                        </StackLayout.GestureRecognizers>
-                        <Label Style="{StaticResource ExpenseCardSubtitle}"
-                               Text="{x:Static resx:AppResources.Saved}"/>
-                        <ProgressBar Style="{StaticResource ExpenseCardProgressBar}"
-                                     Margin="0,8,0,0"
-                                     Progress="{Binding SavedRatio}"/>
-                        <FlexLayout JustifyContent="SpaceBetween">
-                            <Label Style="{StaticResource ExpenseCardProgressValue}"
-                                   Text="{Binding SavedActualAmount}"/>
-                            <Label Style="{StaticResource ExpenseCardProgressValue}"
-                                   Text="{Binding SavedPlannedAmount}" />
-                        </FlexLayout>
-                    </StackLayout>
-                </StackLayout>
-            </Border>
-            
-            <Border Style="{StaticResource ExpenseCard}"
-                    Margin="0, 16, 0, 0">
-                <StackLayout>
-                    <Label Style="{StaticResource ExpenseCardTitle}"
-                           Text="{x:Static resx:AppResources.Categories}"/>
-                    
-                    <Label Style="{StaticResource ExpenseCardSubtitle}" 
-                           IsVisible="{Binding IsDisplayNoCategories}" 
-                           Text="{x:Static resx:AppResources.ThereIsNoCategories}"
-                           Margin="0,16,0,0"
-                           HorizontalTextAlignment="Center"/> 
-                    
-                    <CollectionView x:Name="CategoriesExpensesCollectionView">
-                        <CollectionView.ItemTemplate>
-                            <DataTemplate x:DataType="categories:CategoryExpenseModel">
-                                <StackLayout>
-                                    <StackLayout.GestureRecognizers>
-                                        <TapGestureRecognizer Tapped="CategoryLayout_OnTapped" />
-                                    </StackLayout.GestureRecognizers>
-                                    
-                                    <StackLayout Margin="0,16,0,0"
-                                                 IsVisible="{Binding IsShowRatio}">
-                                        <Label Style="{StaticResource ExpenseCardSubtitle}"
-                                               Text="{Binding Name}" />
-                                        <ProgressBar Style="{StaticResource ExpenseCardProgressBar}"
-                                                     Progress="{Binding Ratio}" 
-                                                     Margin="0, 8,0,0"/>
-                                        <FlexLayout JustifyContent="SpaceBetween">
-                                            <Label Style="{StaticResource ExpenseCardProgressValue}"
-                                                   Text="{Binding ActualAmount}" />
-                                            <Label Style="{StaticResource ExpenseCardProgressValue}"
-                                                   Text="{Binding PlannedAmount}"/>
+                </Border>
+                
+                <Border Style="{StaticResource ExpenseCard}"
+                        Margin="0, 16, 0, 0">
+                    <StackLayout>
+                        <Label Style="{StaticResource ExpenseCardTitle}"
+                               Text="{x:Static resx:AppResources.Categories}"/>
+                        
+                        <Label Style="{StaticResource ExpenseCardSubtitle}" 
+                               IsVisible="{Binding IsDisplayNoCategories}" 
+                               Text="{x:Static resx:AppResources.ThereIsNoCategories}"
+                               Margin="0,16,0,0"
+                               HorizontalTextAlignment="Center"/> 
+                        
+                        <CollectionView x:Name="CategoriesExpensesCollectionView">
+                            <CollectionView.ItemTemplate>
+                                <DataTemplate x:DataType="categories:CategoryExpenseModel">
+                                    <StackLayout>
+                                        <StackLayout.GestureRecognizers>
+                                            <TapGestureRecognizer Tapped="CategoryLayout_OnTapped" />
+                                        </StackLayout.GestureRecognizers>
+                                        
+                                        <StackLayout Margin="0,16,0,0"
+                                                     IsVisible="{Binding IsShowRatio}">
+                                            <Label Style="{StaticResource ExpenseCardSubtitle}"
+                                                   Text="{Binding Name}" />
+                                            <ProgressBar Style="{StaticResource ExpenseCardProgressBar}"
+                                                         Progress="{Binding Ratio}" 
+                                                         Margin="0, 8,0,0"/>
+                                            <FlexLayout JustifyContent="SpaceBetween">
+                                                <Label Style="{StaticResource ExpenseCardProgressValue}"
+                                                       Text="{Binding ActualAmount}" />
+                                                <Label Style="{StaticResource ExpenseCardProgressValue}"
+                                                       Text="{Binding PlannedAmount}"/>
+                                            </FlexLayout>
+                                        </StackLayout>
+                                        
+                                        <FlexLayout JustifyContent="SpaceBetween"
+                                                    Margin="0,16,0,0"
+                                                    IsVisible="{Binding IsNotShowRatio}">
+                                            <Label Style="{StaticResource ExpenseCardSubtitle}"
+                                                   Text="{Binding Name}"/>
+                                            <Label Style="{StaticResource ExpenseCardSubtitle}"
+                                                   Text="{Binding ActualAmount}"/>
                                         </FlexLayout>
                                     </StackLayout>
-                                    
-                                    <FlexLayout JustifyContent="SpaceBetween"
-                                                Margin="0,16,0,0"
-                                                IsVisible="{Binding IsNotShowRatio}">
-                                        <Label Style="{StaticResource ExpenseCardSubtitle}"
-                                               Text="{Binding Name}"/>
-                                        <Label Style="{StaticResource ExpenseCardSubtitle}"
-                                               Text="{Binding ActualAmount}"/>
-                                    </FlexLayout>
-                                </StackLayout>
-                            </DataTemplate>
-                        </CollectionView.ItemTemplate>
-                    </CollectionView>
-                </StackLayout>
-            </Border>
-        </VerticalStackLayout>
-    </ScrollView>
+                                </DataTemplate>
+                            </CollectionView.ItemTemplate>
+                        </CollectionView>
+                    </StackLayout>
+                </Border>
+            </VerticalStackLayout>
+        </ScrollView>
+    </RefreshView>
 </ContentPage>

--- a/src/Profitocracy.Mobile/Views/Home/HomePage.xaml.cs
+++ b/src/Profitocracy.Mobile/Views/Home/HomePage.xaml.cs
@@ -18,9 +18,9 @@ public partial class HomePage : ContentPage
 		CategoriesExpensesCollectionView.ItemsSource = _viewModel.CategoriesExpenses;
 	}
 
-	private void HomePage_OnNavigated(object? sender, EventArgs e)
+	private async void HomePage_OnNavigated(object? sender, EventArgs e)
 	{
-		_viewModel.Initialize();
+		await _viewModel.Initialize();
 	}
 
 	private async void CategoryLayout_OnTapped(object? sender, TappedEventArgs e)
@@ -45,7 +45,7 @@ public partial class HomePage : ContentPage
 			return;
 		}
 		
-		filteredPage.Initialize(
+		await filteredPage.Initialize(
 			_viewModel.ProfileId,
 			category.Id, 
 			spendingType: null, 

--- a/src/Profitocracy.Mobile/Views/Home/HomePage.xaml.cs
+++ b/src/Profitocracy.Mobile/Views/Home/HomePage.xaml.cs
@@ -83,7 +83,7 @@ public partial class HomePage : ContentPage
 			return;
 		}
 		
-		filteredPage.Initialize(
+		await filteredPage.Initialize(
 			_viewModel.ProfileId,
 			categoryId: null, 
 			type,

--- a/src/Profitocracy.Mobile/Views/Settings/CategoriesSettings/ExpenseCategoriesSettingsPage.xaml.cs
+++ b/src/Profitocracy.Mobile/Views/Settings/CategoriesSettings/ExpenseCategoriesSettingsPage.xaml.cs
@@ -16,9 +16,9 @@ public partial class ExpenseCategoriesSettingsPage : ContentPage
 		CategoriesCollectionView.ItemsSource = _viewModel.Categories;
 	}
 
-	private void UpdateCategoriesList(object? sender, EventArgs e)
+	private async void UpdateCategoriesList(object? sender, EventArgs e)
 	{
-		_viewModel.Initialize();
+		await _viewModel.Initialize();
 	}
 
 	private async void AddCategoryButton_OnClicked(object? sender, EventArgs e)

--- a/src/Profitocracy.Mobile/Views/Setup/SetupPage.xaml.cs
+++ b/src/Profitocracy.Mobile/Views/Setup/SetupPage.xaml.cs
@@ -23,7 +23,7 @@ public partial class SetupPage : ContentPage
 	{
 		try
 		{
-			_viewModel.CreateFirstProfile();
+			await _viewModel.CreateFirstProfile();
 			await Navigation.PopModalAsync();
 		}
 		catch (Exception ex)

--- a/src/Profitocracy.Mobile/Views/Transactions/FilteredTransactionsPage.xaml.cs
+++ b/src/Profitocracy.Mobile/Views/Transactions/FilteredTransactionsPage.xaml.cs
@@ -22,7 +22,12 @@ public partial class FilteredTransactionsPage : ContentPage
         await Navigation.PopModalAsync();
     }
     
-    public async void Initialize(Guid profileId, Guid? categoryId, SpendingType? spendingType, DateTime dateFrom, DateTime dateTo)
+    public async Task Initialize(
+        Guid profileId, 
+        Guid? categoryId, 
+        SpendingType? spendingType, 
+        DateTime dateFrom, 
+        DateTime dateTo)
     {
         await _viewModel.Initialize(profileId, categoryId, spendingType, dateFrom, dateTo);
     }

--- a/src/Profitocracy.Mobile/Views/Transactions/TransactionsPage.xaml
+++ b/src/Profitocracy.Mobile/Views/Transactions/TransactionsPage.xaml
@@ -7,7 +7,7 @@
              x:Class="Profitocracy.Mobile.Views.Transactions.TransactionsPage"
              Title="{x:Static resx:AppResources.Transactions}"
              BackgroundColor="{AppThemeBinding Light={StaticResource LightBackground}, Dark={StaticResource DarkBackground}}"
-             NavigatedTo="UpdateTransactionsList">
+             NavigatedTo="TransactionsPage_NavigatedTo">
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="auto"/>

--- a/src/Profitocracy.Mobile/Views/Transactions/TransactionsPage.xaml.cs
+++ b/src/Profitocracy.Mobile/Views/Transactions/TransactionsPage.xaml.cs
@@ -17,7 +17,7 @@ public partial class TransactionsPage : ContentPage
 		TransactionsCollectionView.ItemsSource = _viewModel.Transactions;
 	}
 
-	private async void UpdateTransactionsList(object? sender, EventArgs e)
+	private async void TransactionsPage_NavigatedTo(object? sender, EventArgs e)
 	{
 		await _viewModel.Initialize();
 	}


### PR DESCRIPTION
## Features

- Added **Pull to refresh** action to HomePage. It was needed because when you reopen the application at next day it would show you data for previous day;

## Fixed bugs

- Fixed an issue which caused to not including transactions made at the last day of month into transactions list and calculation process of profile;
- Fixed an issue which was causing to decreasing a `PlannedAmount` of today expenses with every new today expense transaction;
- Fixed an issue when savings transactions which are not from current month was not included into calculation process of profile, and because of that you could not see total amount of saved money;
- Removed redundant `async void` from ViewModels;