### PR TITLE
Amount for tomorrow. Localization improvements

### DIFF
--- a/src/Profitocracy.Core/Domain/Model/Profiles/ValueObjects/ProfileExpenses.cs
+++ b/src/Profitocracy.Core/Domain/Model/Profiles/ValueObjects/ProfileExpenses.cs
@@ -7,19 +7,19 @@ namespace Profitocracy.Core.Domain.Model.Profiles.ValueObjects;
 public class ProfileExpenses
 {
 	/// <summary>
+	/// Daily amount for tomorrow
+	/// </summary>
+	public required decimal TomorrowBalance { get; set; }
+	
+	/// <summary>
 	/// Total amount of expenses
 	/// </summary>
 	public required ProfileExpense TotalBalance { get; init; }
 	
 	/// <summary>
-	/// Daily amounts from actual profile balance
+	/// Daily amount for today
 	/// </summary>
-	public required ProfileExpense DailyFromActualBalance { get; init; }
-	
-	/// <summary>
-	/// Daily amounts from initial profile balance
-	/// </summary>
-	public required ProfileExpense DailyFromInitialBalance { get; init; }
+	public required ProfileExpense TodayBalance { get; init; }
 	
 	/// <summary>
 	/// Main expenses amount

--- a/src/Profitocracy.Core/Domain/Services/ProfileService.cs
+++ b/src/Profitocracy.Core/Domain/Services/ProfileService.cs
@@ -7,6 +7,11 @@ using Profitocracy.Core.Specifications;
 
 namespace Profitocracy.Core.Domain.Services;
 
+/// <summary>
+/// This internal implementation of <see cref="IProfileService"/> is used
+/// because only it should know about <see cref="Profile"/> implementation
+/// details and how to deal with them. 
+/// </summary>
 internal class ProfileService : IProfileService
 {
 	private readonly IProfileRepository _profileRepository;

--- a/src/Profitocracy.Mobile/AppShell.xaml
+++ b/src/Profitocracy.Mobile/AppShell.xaml
@@ -8,13 +8,13 @@
        x:Class="Profitocracy.Mobile.AppShell"
        Loaded="AppShell_OnLoaded">
     <TabBar>
-        <Tab Title="{x:Static resx:AppResources.Home}" Icon="home.png">
+        <Tab Title="{x:Static resx:AppResources.Pages_Home}" Icon="home.png">
             <ShellContent ContentTemplate="{DataTemplate home:HomePage}"/>
         </Tab>
-        <Tab Title="{x:Static resx:AppResources.Transactions}" Icon="transactions.png">
+        <Tab Title="{x:Static resx:AppResources.Pages_Transactions}" Icon="transactions.png">
             <ShellContent ContentTemplate="{DataTemplate transactions:TransactionsPage}"/>
         </Tab>
-        <Tab Title="{x:Static resx:AppResources.Settings}" Icon="settings.png">
+        <Tab Title="{x:Static resx:AppResources.Pages_Settings}" Icon="settings.png">
             <ShellContent ContentTemplate="{DataTemplate settings:SettingsPage}"/>
         </Tab>
     </TabBar>

--- a/src/Profitocracy.Mobile/Models/Categories/CategoryModel.cs
+++ b/src/Profitocracy.Mobile/Models/Categories/CategoryModel.cs
@@ -16,7 +16,7 @@ public class CategoryModel
     {
         var displayPlannedAmount = category.PlannedAmount is not null
             ? category.PlannedAmount.ToString()
-            : AppResources.NoLimits;
+            : AppResources.Categories_NoLimits;
         
         return new CategoryModel
         {

--- a/src/Profitocracy.Mobile/Models/Transactions/TransactionModel.cs
+++ b/src/Profitocracy.Mobile/Models/Transactions/TransactionModel.cs
@@ -1,3 +1,4 @@
+using Profitocracy.Core.Domain.Model.Transactions;
 using Profitocracy.Mobile.Resources.Strings;
 
 namespace Profitocracy.Mobile.Models.Transactions;
@@ -6,10 +7,10 @@ public class TransactionModel
 {
     private readonly string[] _spendingTypes =
     [
-        AppResources.Main,
-        AppResources.Secondary,
-        AppResources.Saved,
-        AppResources.Income
+        AppResources.Transactions_Main,
+        AppResources.Transactions_Secondary,
+        AppResources.Transactions_Saved,
+        AppResources.Transactions_Income
     ];
     
     public Guid? Id { get; set; }
@@ -38,7 +39,7 @@ public class TransactionModel
         }
     }
 
-    public static TransactionModel FromDomain(Core.Domain.Model.Transactions.Transaction transaction)
+    public static TransactionModel FromDomain(Transaction transaction)
     {
         TransactionCategoryModel? category = null;
 

--- a/src/Profitocracy.Mobile/Profitocracy.Mobile.csproj
+++ b/src/Profitocracy.Mobile/Profitocracy.Mobile.csproj
@@ -15,8 +15,8 @@
         <ApplicationTitle>Profitocracy</ApplicationTitle>
         <ApplicationId>com.krawmire.profitocracy</ApplicationId>
         
-        <ApplicationVersion>19</ApplicationVersion>
-        <ApplicationDisplayVersion>1.3.5</ApplicationDisplayVersion>
+        <ApplicationVersion>20</ApplicationVersion>
+        <ApplicationDisplayVersion>1.4.0</ApplicationDisplayVersion>
     </PropertyGroup>
 
     <PropertyGroup Condition="$(TargetFramework.Contains('-ios'))">

--- a/src/Profitocracy.Mobile/Profitocracy.Mobile.csproj
+++ b/src/Profitocracy.Mobile/Profitocracy.Mobile.csproj
@@ -1,43 +1,22 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <!-- I have used net8.0 for Android just because somewhy dotnet does not see Android SDK if I select net9.0 -->
-        <TargetFrameworks>net8.0-android;net9.0-ios;net9.0-maccatalyst;</TargetFrameworks>
-        <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net9.0-windows10.0.19041.0</TargetFrameworks>
-
-        <!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
-        <!-- <TargetFrameworks>$(TargetFrameworks);net8.0-tizen</TargetFrameworks> -->
-
-        <!-- Note for MacCatalyst:
-        The default runtime is maccatalyst-x64, except in Release config, in which case the default is maccatalyst-x64;maccatalyst-arm64.
-        When specifying both architectures, use the plural <RuntimeIdentifiers> instead of the singular <RuntimeIdentifier>.
-        The Mac App Store will NOT accept apps with ONLY maccatalyst-arm64 indicated;
-        either BOTH runtimes must be indicated or ONLY macatalyst-x64. -->
-        <!-- For example: <RuntimeIdentifiers>maccatalyst-x64;maccatalyst-arm64</RuntimeIdentifiers> -->
+        <TargetFrameworks>net9.0-android;net9.0-ios;</TargetFrameworks>
+        <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">12.2</SupportedOSPlatformVersion>
+        <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
 
         <OutputType>Exe</OutputType>
         <RootNamespace>Profitocracy.Mobile</RootNamespace>
-        <UseMaui>true</UseMaui>
-        <SingleProject>true</SingleProject>
         <ImplicitUsings>enable</ImplicitUsings>
+        <SingleProject>true</SingleProject>
         <Nullable>enable</Nullable>
+        <UseMaui>true</UseMaui>
 
-        <!-- Display name -->
         <ApplicationTitle>Profitocracy</ApplicationTitle>
-
-        <!-- App Identifier -->
         <ApplicationId>com.krawmire.profitocracy</ApplicationId>
-
-        <!-- Versions -->
-        <ApplicationDisplayVersion>1.3.5</ApplicationDisplayVersion>
+        
         <ApplicationVersion>19</ApplicationVersion>
-
-        <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">12.2</SupportedOSPlatformVersion>
-        <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">15.0</SupportedOSPlatformVersion>
-        <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
-        <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
-        <TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
-        <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
+        <ApplicationDisplayVersion>1.3.5</ApplicationDisplayVersion>
     </PropertyGroup>
 
     <PropertyGroup Condition="$(TargetFramework.Contains('-ios'))">
@@ -45,26 +24,29 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <!-- App Icon -->
+        <ProjectReference Include="..\Profitocracy.Core\Profitocracy.Core.csproj" />
+        <ProjectReference Include="..\Profitocracy.Infrastructure\Profitocracy.Infrastructure.csproj" />
+    </ItemGroup>
+    
+    <ItemGroup>
+        <PackageReference Include="CommunityToolkit.Maui" Version="9.0.3" />
+        <PackageReference Include="Microsoft.Maui.Controls" Version="8.0.90" />
+        <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.91" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0"/>
+    </ItemGroup>
+
+    <ItemGroup>
         <MauiIcon Include="Resources\AppIcon\appicon.svg"
                   BaseSize="128,128"
                   Resize="false"
                   ForegroundFile="Resources\AppIcon\appiconfg.svg"
                   Color="#ffffff"/>
-
-        <!-- Splash Screen -->
         <MauiSplashScreen Include="Resources\Splash\splash.svg"
                           BaseSize="500,575"
                           Resize="false"
                           Color="#ffffff"/>
-
-        <!-- Images -->
         <MauiImage Include="Resources\Images\*"/>
-
-        <!-- Custom Fonts -->
         <MauiFont Include="Resources\Fonts\*"/>
-
-        <!-- Raw Assets (also remove the "Resources\Raw" prefix) -->
         <MauiAsset Include="Resources\Raw\**" LogicalName="%(RecursiveDir)%(Filename)%(Extension)"/>
     </ItemGroup>
 
@@ -74,35 +56,28 @@
         <MauiImage Update="Resources\Images\transactions.png" BaseSize="24,24" />
         <MauiImage Update="Resources\Images\settings.png" BaseSize="24,24" />
 
-        <!-- Used by the rest of application -->
+        <!-- Used by the rest of the application -->
         <MauiImage Update="Resources\Images\bin_red.png" BaseSize="20,20" />
         <MauiImage Update="Resources\Images\bin.png" BaseSize="20,20" />
         <MauiImage Update="Resources\Images\currencies.png" BaseSize="20,20" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="CommunityToolkit.Maui" Version="9.0.3" />
-        <PackageReference Include="Microsoft.Maui.Controls" Version="8.0.90" />
-        <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.91" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0"/>
-    </ItemGroup>
-
-    <ItemGroup>
-      <MauiXaml Update="Pages\Settings\SettingsPage.xaml">
-        <SubType>Designer</SubType>
-      </MauiXaml>
-      <MauiXaml Update="Pages\Transactions\TransactionsPage.xaml">
-        <SubType>Designer</SubType>
-      </MauiXaml>
-      <MauiXaml Update="Pages\Home\HomePage.xaml">
-        <SubType>Designer</SubType>
-      </MauiXaml>
-      <MauiXaml Update="Pages\CurrencyRates\CurrencyRatesPage.xaml">
-        <SubType>Designer</SubType>
-      </MauiXaml>
-      <MauiXaml Update="Views\Settings\CategoriesSettings\ExpenseCategoriesSettingsPage.xaml">
-        <SubType>Designer</SubType>
-      </MauiXaml>
+        <MauiXaml Update="Pages\Home\HomePage.xaml">
+            <SubType>Designer</SubType>
+        </MauiXaml>
+        <MauiXaml Update="Pages\Settings\SettingsPage.xaml">
+            <SubType>Designer</SubType>
+        </MauiXaml>
+        <MauiXaml Update="Pages\Transactions\TransactionsPage.xaml">
+            <SubType>Designer</SubType>
+        </MauiXaml>
+        <MauiXaml Update="Pages\CurrencyRates\CurrencyRatesPage.xaml">
+            <SubType>Designer</SubType>
+        </MauiXaml>
+        <MauiXaml Update="Views\Settings\CategoriesSettings\ExpenseCategoriesSettingsPage.xaml">
+            <SubType>Designer</SubType>
+        </MauiXaml>
     </ItemGroup>
 
     <ItemGroup>
@@ -136,11 +111,6 @@
         <AutoGen>True</AutoGen>
         <DependentUpon>AppResources.ru.resx</DependentUpon>
       </Compile>
-    </ItemGroup>
-
-    <ItemGroup>
-      <ProjectReference Include="..\Profitocracy.Core\Profitocracy.Core.csproj" />
-      <ProjectReference Include="..\Profitocracy.Infrastructure\Profitocracy.Infrastructure.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Profitocracy.Mobile/Resources/Strings/AppResources.Designer.cs
+++ b/src/Profitocracy.Mobile/Resources/Strings/AppResources.Designer.cs
@@ -69,15 +69,15 @@ namespace Profitocracy.Mobile.Resources.Strings {
             }
         }
         
-        internal static string Home_FromInitialBalance {
+        internal static string Home_TomorrowBalance {
             get {
-                return ResourceManager.GetString("Home_FromInitialBalance", resourceCulture);
+                return ResourceManager.GetString("Home_TomorrowBalance", resourceCulture);
             }
         }
         
-        internal static string Home_FromActualBalance {
+        internal static string Home_TodayBalance {
             get {
-                return ResourceManager.GetString("Home_FromActualBalance", resourceCulture);
+                return ResourceManager.GetString("Home_TodayBalance", resourceCulture);
             }
         }
         

--- a/src/Profitocracy.Mobile/Resources/Strings/AppResources.Designer.cs
+++ b/src/Profitocracy.Mobile/Resources/Strings/AppResources.Designer.cs
@@ -45,279 +45,279 @@ namespace Profitocracy.Mobile.Resources.Strings {
             }
         }
         
-        internal static string CreateFirstProfile {
+        internal static string Setup_FirstProfile {
             get {
-                return ResourceManager.GetString("CreateFirstProfile", resourceCulture);
+                return ResourceManager.GetString("Setup_FirstProfile", resourceCulture);
             }
         }
         
-        internal static string Home {
+        internal static string Pages_Home {
             get {
-                return ResourceManager.GetString("Home", resourceCulture);
+                return ResourceManager.GetString("Pages_Home", resourceCulture);
             }
         }
         
-        internal static string Balance {
+        internal static string Home_Balance {
             get {
-                return ResourceManager.GetString("Balance", resourceCulture);
+                return ResourceManager.GetString("Home_Balance", resourceCulture);
             }
         }
         
-        internal static string DailyAmounts {
+        internal static string Home_DailyAmounts {
             get {
-                return ResourceManager.GetString("DailyAmounts", resourceCulture);
+                return ResourceManager.GetString("Home_DailyAmounts", resourceCulture);
             }
         }
         
-        internal static string FromInitialBalance {
+        internal static string Home_FromInitialBalance {
             get {
-                return ResourceManager.GetString("FromInitialBalance", resourceCulture);
+                return ResourceManager.GetString("Home_FromInitialBalance", resourceCulture);
             }
         }
         
-        internal static string FromActualBalance {
+        internal static string Home_FromActualBalance {
             get {
-                return ResourceManager.GetString("FromActualBalance", resourceCulture);
+                return ResourceManager.GetString("Home_FromActualBalance", resourceCulture);
             }
         }
         
-        internal static string SpendingTypes {
+        internal static string Home_SpendingTypes {
             get {
-                return ResourceManager.GetString("SpendingTypes", resourceCulture);
+                return ResourceManager.GetString("Home_SpendingTypes", resourceCulture);
             }
         }
         
-        internal static string Main {
+        internal static string Home_Main {
             get {
-                return ResourceManager.GetString("Main", resourceCulture);
+                return ResourceManager.GetString("Home_Main", resourceCulture);
             }
         }
         
-        internal static string Secondary {
+        internal static string Home_Secondary {
             get {
-                return ResourceManager.GetString("Secondary", resourceCulture);
+                return ResourceManager.GetString("Home_Secondary", resourceCulture);
             }
         }
         
-        internal static string Saved {
+        internal static string Home_Saved {
             get {
-                return ResourceManager.GetString("Saved", resourceCulture);
+                return ResourceManager.GetString("Home_Saved", resourceCulture);
             }
         }
         
-        internal static string Categories {
+        internal static string Settings_Categories {
             get {
-                return ResourceManager.GetString("Categories", resourceCulture);
+                return ResourceManager.GetString("Settings_Categories", resourceCulture);
             }
         }
         
-        internal static string ThereIsNoCategories {
+        internal static string Home_NoCategories {
             get {
-                return ResourceManager.GetString("ThereIsNoCategories", resourceCulture);
+                return ResourceManager.GetString("Home_NoCategories", resourceCulture);
             }
         }
         
-        internal static string SavedBalance {
+        internal static string Home_SavedBalance {
             get {
-                return ResourceManager.GetString("SavedBalance", resourceCulture);
+                return ResourceManager.GetString("Home_SavedBalance", resourceCulture);
             }
         }
         
-        internal static string ProfileName {
+        internal static string Setup_ProfileName {
             get {
-                return ResourceManager.GetString("ProfileName", resourceCulture);
+                return ResourceManager.GetString("Setup_ProfileName", resourceCulture);
             }
         }
         
-        internal static string InitialBalance {
+        internal static string Setup_InitialBalance {
             get {
-                return ResourceManager.GetString("InitialBalance", resourceCulture);
+                return ResourceManager.GetString("Setup_InitialBalance", resourceCulture);
             }
         }
         
-        internal static string GoToExpenses {
+        internal static string Setup_GoToExpenses {
             get {
-                return ResourceManager.GetString("GoToExpenses", resourceCulture);
+                return ResourceManager.GetString("Setup_GoToExpenses", resourceCulture);
             }
         }
         
-        internal static string Transactions {
+        internal static string Pages_Transactions {
             get {
-                return ResourceManager.GetString("Transactions", resourceCulture);
+                return ResourceManager.GetString("Pages_Transactions", resourceCulture);
             }
         }
         
-        internal static string Income {
+        internal static string AddTransaction_Income {
             get {
-                return ResourceManager.GetString("Income", resourceCulture);
+                return ResourceManager.GetString("AddTransaction_Income", resourceCulture);
             }
         }
         
-        internal static string Settings {
+        internal static string Pages_Settings {
             get {
-                return ResourceManager.GetString("Settings", resourceCulture);
+                return ResourceManager.GetString("Pages_Settings", resourceCulture);
             }
         }
         
-        internal static string AddNewTransaction {
+        internal static string Pages_NewTransaction {
             get {
-                return ResourceManager.GetString("AddNewTransaction", resourceCulture);
+                return ResourceManager.GetString("Pages_NewTransaction", resourceCulture);
             }
         }
         
-        internal static string Expense {
+        internal static string AddTransaction_Expense {
             get {
-                return ResourceManager.GetString("Expense", resourceCulture);
+                return ResourceManager.GetString("AddTransaction_Expense", resourceCulture);
             }
         }
         
-        internal static string Category {
+        internal static string AddTransaction_Category {
             get {
-                return ResourceManager.GetString("Category", resourceCulture);
+                return ResourceManager.GetString("AddTransaction_Category", resourceCulture);
             }
         }
         
-        internal static string Amount {
+        internal static string AddTransaction_Amount {
             get {
-                return ResourceManager.GetString("Amount", resourceCulture);
+                return ResourceManager.GetString("AddTransaction_Amount", resourceCulture);
             }
         }
         
-        internal static string Description {
+        internal static string AddTransaction_Description {
             get {
-                return ResourceManager.GetString("Description", resourceCulture);
+                return ResourceManager.GetString("AddTransaction_Description", resourceCulture);
             }
         }
         
-        internal static string Date {
+        internal static string AddTransaction_Date {
             get {
-                return ResourceManager.GetString("Date", resourceCulture);
+                return ResourceManager.GetString("AddTransaction_Date", resourceCulture);
             }
         }
         
-        internal static string SaveTransaction {
+        internal static string AddTransaction_SaveTransaction {
             get {
-                return ResourceManager.GetString("SaveTransaction", resourceCulture);
+                return ResourceManager.GetString("AddTransaction_SaveTransaction", resourceCulture);
             }
         }
         
-        internal static string Application {
+        internal static string Settings_Application {
             get {
-                return ResourceManager.GetString("Application", resourceCulture);
+                return ResourceManager.GetString("Settings_Application", resourceCulture);
             }
         }
         
-        internal static string General {
+        internal static string Settings_General {
             get {
-                return ResourceManager.GetString("General", resourceCulture);
+                return ResourceManager.GetString("Settings_General", resourceCulture);
             }
         }
         
-        internal static string Profiles {
+        internal static string Settings_Profiles {
             get {
-                return ResourceManager.GetString("Profiles", resourceCulture);
+                return ResourceManager.GetString("Settings_Profiles", resourceCulture);
             }
         }
         
-        internal static string Theme {
+        internal static string Settings_Theme {
             get {
-                return ResourceManager.GetString("Theme", resourceCulture);
+                return ResourceManager.GetString("Settings_Theme", resourceCulture);
             }
         }
         
-        internal static string Language {
+        internal static string Settings_Language {
             get {
-                return ResourceManager.GetString("Language", resourceCulture);
+                return ResourceManager.GetString("Settings_Language", resourceCulture);
             }
         }
         
-        internal static string NoLimits {
+        internal static string Categories_NoLimits {
             get {
-                return ResourceManager.GetString("NoLimits", resourceCulture);
+                return ResourceManager.GetString("Categories_NoLimits", resourceCulture);
             }
         }
         
-        internal static string AddNewCategory {
+        internal static string Pages_NewCategory {
             get {
-                return ResourceManager.GetString("AddNewCategory", resourceCulture);
+                return ResourceManager.GetString("Pages_NewCategory", resourceCulture);
             }
         }
         
-        internal static string CategoryName {
+        internal static string AddCategory_CategoryName {
             get {
-                return ResourceManager.GetString("CategoryName", resourceCulture);
+                return ResourceManager.GetString("AddCategory_CategoryName", resourceCulture);
             }
         }
         
-        internal static string SpecifyPlannedAmount {
+        internal static string AddCategory_SpecifyPlannedAmount {
             get {
-                return ResourceManager.GetString("SpecifyPlannedAmount", resourceCulture);
+                return ResourceManager.GetString("AddCategory_SpecifyPlannedAmount", resourceCulture);
             }
         }
         
-        internal static string PlannedAmount {
+        internal static string AddCategory_PlannedAmount {
             get {
-                return ResourceManager.GetString("PlannedAmount", resourceCulture);
+                return ResourceManager.GetString("AddCategory_PlannedAmount", resourceCulture);
             }
         }
         
-        internal static string SaveCategory {
+        internal static string AddCategory_SaveCategory {
             get {
-                return ResourceManager.GetString("SaveCategory", resourceCulture);
+                return ResourceManager.GetString("AddCategory_SaveCategory", resourceCulture);
             }
         }
         
-        internal static string DateRange {
+        internal static string Transactions_DateRange {
             get {
-                return ResourceManager.GetString("DateRange", resourceCulture);
+                return ResourceManager.GetString("Transactions_DateRange", resourceCulture);
             }
         }
         
-        internal static string LightThemeText {
+        internal static string ThemeSettings_LightTheme {
             get {
-                return ResourceManager.GetString("LightThemeText", resourceCulture);
+                return ResourceManager.GetString("ThemeSettings_LightTheme", resourceCulture);
             }
         }
         
-        internal static string DarkThemeText {
+        internal static string ThemeSettings_Dark {
             get {
-                return ResourceManager.GetString("DarkThemeText", resourceCulture);
+                return ResourceManager.GetString("ThemeSettings_Dark", resourceCulture);
             }
         }
         
-        internal static string SystemThemeText {
+        internal static string ThemeSettings_System {
             get {
-                return ResourceManager.GetString("SystemThemeText", resourceCulture);
+                return ResourceManager.GetString("ThemeSettings_System", resourceCulture);
             }
         }
         
-        internal static string EnglishLanguage {
+        internal static string Languages_English {
             get {
-                return ResourceManager.GetString("EnglishLanguage", resourceCulture);
+                return ResourceManager.GetString("Languages_English", resourceCulture);
             }
         }
         
-        internal static string RussianLanguage {
+        internal static string Languages_Russian {
             get {
-                return ResourceManager.GetString("RussianLanguage", resourceCulture);
+                return ResourceManager.GetString("Languages_Russian", resourceCulture);
             }
         }
         
-        internal static string ChangeLanguageAlertTitle {
+        internal static string InfoAlert_ChangeLanguage_Title {
             get {
-                return ResourceManager.GetString("ChangeLanguageAlertTitle", resourceCulture);
+                return ResourceManager.GetString("InfoAlert_ChangeLanguage_Title", resourceCulture);
             }
         }
         
-        internal static string ChangeLanguageAlertMessage {
+        internal static string InfoAlert_ChangeLanguage_Message {
             get {
-                return ResourceManager.GetString("ChangeLanguageAlertMessage", resourceCulture);
+                return ResourceManager.GetString("InfoAlert_ChangeLanguage_Message", resourceCulture);
             }
         }
         
-        internal static string ChangeLanguageAlertOk {
+        internal static string InfoAlert_ChangeLanguage_Ok {
             get {
-                return ResourceManager.GetString("ChangeLanguageAlertOk", resourceCulture);
+                return ResourceManager.GetString("InfoAlert_ChangeLanguage_Ok", resourceCulture);
             }
         }
         
@@ -339,39 +339,39 @@ namespace Profitocracy.Mobile.Resources.Strings {
             }
         }
         
-        internal static string ErrorAlert_GetCategoryInfo {
+        internal static string CommonError_GetCategoryInfo {
             get {
-                return ResourceManager.GetString("ErrorAlert_GetCategoryInfo", resourceCulture);
+                return ResourceManager.GetString("CommonError_GetCategoryInfo", resourceCulture);
             }
         }
         
-        internal static string ErrorAlert_ShowFilteredTransactions {
+        internal static string CommonError_ShowFilteredTransactions {
             get {
-                return ResourceManager.GetString("ErrorAlert_ShowFilteredTransactions", resourceCulture);
+                return ResourceManager.GetString("CommonError_ShowFilteredTransactions", resourceCulture);
             }
         }
         
-        internal static string ErrorAlert_OpenAddCategoryPage {
+        internal static string CommonError_OpenAddCategoryPage {
             get {
-                return ResourceManager.GetString("ErrorAlert_OpenAddCategoryPage", resourceCulture);
+                return ResourceManager.GetString("CommonError_OpenAddCategoryPage", resourceCulture);
             }
         }
         
-        internal static string ErrorAlert_OpenAddTransactionPage {
+        internal static string CommonError_OpenAddTransactionPage {
             get {
-                return ResourceManager.GetString("ErrorAlert_OpenAddTransactionPage", resourceCulture);
+                return ResourceManager.GetString("CommonError_OpenAddTransactionPage", resourceCulture);
             }
         }
         
-        internal static string ErrorAlert_InternalErrorTryAgain {
+        internal static string CommonError_InternalErrorTryAgain {
             get {
-                return ResourceManager.GetString("ErrorAlert_InternalErrorTryAgain", resourceCulture);
+                return ResourceManager.GetString("CommonError_InternalErrorTryAgain", resourceCulture);
             }
         }
         
-        internal static string ErrorAlert_FindTransactionToDelete {
+        internal static string CommonError_FindTransactionToDelete {
             get {
-                return ResourceManager.GetString("ErrorAlert_FindTransactionToDelete", resourceCulture);
+                return ResourceManager.GetString("CommonError_FindTransactionToDelete", resourceCulture);
             }
         }
         
@@ -414,6 +414,72 @@ namespace Profitocracy.Mobile.Resources.Strings {
         internal static string CommonError_TransactionType {
             get {
                 return ResourceManager.GetString("CommonError_TransactionType", resourceCulture);
+            }
+        }
+        
+        internal static string Pages_Language {
+            get {
+                return ResourceManager.GetString("Pages_Language", resourceCulture);
+            }
+        }
+        
+        internal static string Pages_Categories {
+            get {
+                return ResourceManager.GetString("Pages_Categories", resourceCulture);
+            }
+        }
+        
+        internal static string Pages_Theme {
+            get {
+                return ResourceManager.GetString("Pages_Theme", resourceCulture);
+            }
+        }
+        
+        internal static string Home_Categories {
+            get {
+                return ResourceManager.GetString("Home_Categories", resourceCulture);
+            }
+        }
+        
+        internal static string AddTransaction_Main {
+            get {
+                return ResourceManager.GetString("AddTransaction_Main", resourceCulture);
+            }
+        }
+        
+        internal static string AddTransaction_Secondary {
+            get {
+                return ResourceManager.GetString("AddTransaction_Secondary", resourceCulture);
+            }
+        }
+        
+        internal static string AddTransaction_Saved {
+            get {
+                return ResourceManager.GetString("AddTransaction_Saved", resourceCulture);
+            }
+        }
+        
+        internal static string Transactions_Main {
+            get {
+                return ResourceManager.GetString("Transactions_Main", resourceCulture);
+            }
+        }
+        
+        internal static string Transactions_Secondary {
+            get {
+                return ResourceManager.GetString("Transactions_Secondary", resourceCulture);
+            }
+        }
+        
+        internal static string Transactions_Saved {
+            get {
+                return ResourceManager.GetString("Transactions_Saved", resourceCulture);
+            }
+        }
+        
+        internal static string Transactions_Income {
+            get {
+                return ResourceManager.GetString("Transactions_Income", resourceCulture);
             }
         }
     }

--- a/src/Profitocracy.Mobile/Resources/Strings/AppResources.resx
+++ b/src/Profitocracy.Mobile/Resources/Strings/AppResources.resx
@@ -30,11 +30,11 @@
     <data name="Home_DailyAmounts" xml:space="preserve">
         <value>Daily amounts</value>
     </data>
-    <data name="Home_FromInitialBalance" xml:space="preserve">
-        <value>From initial balance</value>
+    <data name="Home_TomorrowBalance" xml:space="preserve">
+        <value>Tomorrow</value>
     </data>
-    <data name="Home_FromActualBalance" xml:space="preserve">
-        <value>From actual balance</value>
+    <data name="Home_TodayBalance" xml:space="preserve">
+        <value>Today</value>
     </data>
     <data name="Home_SpendingTypes" xml:space="preserve">
         <value>Spending types</value>

--- a/src/Profitocracy.Mobile/Resources/Strings/AppResources.resx
+++ b/src/Profitocracy.Mobile/Resources/Strings/AppResources.resx
@@ -18,142 +18,142 @@
     <resheader name="writer">
         <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
     </resheader>
-    <data name="CreateFirstProfile" xml:space="preserve">
-        <value>Create first profile</value>
+    <data name="Setup_FirstProfile" xml:space="preserve">
+        <value>First profile</value>
     </data>
-    <data name="Home" xml:space="preserve">
+    <data name="Pages_Home" xml:space="preserve">
         <value>Home</value>
     </data>
-    <data name="Balance" xml:space="preserve">
+    <data name="Home_Balance" xml:space="preserve">
         <value>Balance</value>
     </data>
-    <data name="DailyAmounts" xml:space="preserve">
+    <data name="Home_DailyAmounts" xml:space="preserve">
         <value>Daily amounts</value>
     </data>
-    <data name="FromInitialBalance" xml:space="preserve">
+    <data name="Home_FromInitialBalance" xml:space="preserve">
         <value>From initial balance</value>
     </data>
-    <data name="FromActualBalance" xml:space="preserve">
+    <data name="Home_FromActualBalance" xml:space="preserve">
         <value>From actual balance</value>
     </data>
-    <data name="SpendingTypes" xml:space="preserve">
+    <data name="Home_SpendingTypes" xml:space="preserve">
         <value>Spending types</value>
     </data>
-    <data name="Main" xml:space="preserve">
+    <data name="Home_Main" xml:space="preserve">
         <value>Main</value>
     </data>
-    <data name="Secondary" xml:space="preserve">
+    <data name="Home_Secondary" xml:space="preserve">
         <value>Secondary</value>
     </data>
-    <data name="Saved" xml:space="preserve">
+    <data name="Home_Saved" xml:space="preserve">
         <value>Saved</value>
     </data>
-    <data name="Categories" xml:space="preserve">
+    <data name="Settings_Categories" xml:space="preserve">
         <value>Categories</value>
     </data>
-    <data name="ThereIsNoCategories" xml:space="preserve">
+    <data name="Home_NoCategories" xml:space="preserve">
         <value>There is no categories</value>
     </data>
-    <data name="SavedBalance" xml:space="preserve">
+    <data name="Home_SavedBalance" xml:space="preserve">
         <value>Saved</value>
     </data>
-    <data name="ProfileName" xml:space="preserve">
+    <data name="Setup_ProfileName" xml:space="preserve">
         <value>Profile name</value>
     </data>
-    <data name="InitialBalance" xml:space="preserve">
+    <data name="Setup_InitialBalance" xml:space="preserve">
         <value>Initial balance</value>
     </data>
-    <data name="GoToExpenses" xml:space="preserve">
+    <data name="Setup_GoToExpenses" xml:space="preserve">
         <value>Go to expenses</value>
     </data>
-    <data name="Transactions" xml:space="preserve">
+    <data name="Pages_Transactions" xml:space="preserve">
         <value>Transactions</value>
     </data>
-    <data name="Income" xml:space="preserve">
+    <data name="AddTransaction_Income" xml:space="preserve">
         <value>Income</value>
     </data>
-    <data name="Settings" xml:space="preserve">
+    <data name="Pages_Settings" xml:space="preserve">
         <value>Settings</value>
     </data>
-    <data name="AddNewTransaction" xml:space="preserve">
-        <value>Add new transaction</value>
+    <data name="Pages_NewTransaction" xml:space="preserve">
+        <value>New transaction</value>
     </data>
-    <data name="Expense" xml:space="preserve">
+    <data name="AddTransaction_Expense" xml:space="preserve">
         <value>Expense</value>
     </data>
-    <data name="Category" xml:space="preserve">
+    <data name="AddTransaction_Category" xml:space="preserve">
         <value>Category</value>
     </data>
-    <data name="Amount" xml:space="preserve">
+    <data name="AddTransaction_Amount" xml:space="preserve">
         <value>Amount</value>
     </data>
-    <data name="Description" xml:space="preserve">
+    <data name="AddTransaction_Description" xml:space="preserve">
         <value>Description</value>
     </data>
-    <data name="Date" xml:space="preserve">
+    <data name="AddTransaction_Date" xml:space="preserve">
         <value>Date</value>
     </data>
-    <data name="SaveTransaction" xml:space="preserve">
+    <data name="AddTransaction_SaveTransaction" xml:space="preserve">
         <value>Save transaction</value>
     </data>
-    <data name="Application" xml:space="preserve">
+    <data name="Settings_Application" xml:space="preserve">
         <value>Application</value>
     </data>
-    <data name="General" xml:space="preserve">
+    <data name="Settings_General" xml:space="preserve">
         <value>General</value>
     </data>
-    <data name="Profiles" xml:space="preserve">
+    <data name="Settings_Profiles" xml:space="preserve">
         <value>Profiles</value>
     </data>
-    <data name="Theme" xml:space="preserve">
+    <data name="Settings_Theme" xml:space="preserve">
         <value>Theme</value>
     </data>
-    <data name="Language" xml:space="preserve">
+    <data name="Settings_Language" xml:space="preserve">
         <value>Language</value>
     </data>
-    <data name="NoLimits" xml:space="preserve">
+    <data name="Categories_NoLimits" xml:space="preserve">
         <value>No limits</value>
     </data>
-    <data name="AddNewCategory" xml:space="preserve">
-        <value>Add new category</value>
+    <data name="Pages_NewCategory" xml:space="preserve">
+        <value>New category</value>
     </data>
-    <data name="CategoryName" xml:space="preserve">
+    <data name="AddCategory_CategoryName" xml:space="preserve">
         <value>Category name</value>
     </data>
-    <data name="SpecifyPlannedAmount" xml:space="preserve">
+    <data name="AddCategory_SpecifyPlannedAmount" xml:space="preserve">
         <value>Specify planned amount</value>
     </data>
-    <data name="PlannedAmount" xml:space="preserve">
+    <data name="AddCategory_PlannedAmount" xml:space="preserve">
         <value>Planned amount</value>
     </data>
-    <data name="SaveCategory" xml:space="preserve">
+    <data name="AddCategory_SaveCategory" xml:space="preserve">
         <value>Save category</value>
     </data>
-    <data name="DateRange" xml:space="preserve">
+    <data name="Transactions_DateRange" xml:space="preserve">
         <value>Filter by date</value>
     </data>
-    <data name="LightThemeText" xml:space="preserve">
+    <data name="ThemeSettings_LightTheme" xml:space="preserve">
         <value>Light</value>
     </data>
-    <data name="DarkThemeText" xml:space="preserve">
+    <data name="ThemeSettings_Dark" xml:space="preserve">
         <value>Dark</value>
     </data>
-    <data name="SystemThemeText" xml:space="preserve">
+    <data name="ThemeSettings_System" xml:space="preserve">
         <value>System</value>
     </data>
-    <data name="EnglishLanguage" xml:space="preserve">
+    <data name="Languages_English" xml:space="preserve">
         <value>English</value>
     </data>
-    <data name="RussianLanguage" xml:space="preserve">
+    <data name="Languages_Russian" xml:space="preserve">
         <value>Russian</value>
     </data>
-    <data name="ChangeLanguageAlertTitle" xml:space="preserve">
+    <data name="InfoAlert_ChangeLanguage_Title" xml:space="preserve">
         <value>Warning</value>
     </data>
-    <data name="ChangeLanguageAlertMessage" xml:space="preserve">
+    <data name="InfoAlert_ChangeLanguage_Message" xml:space="preserve">
         <value>To make the changes take effect, you need to restart the application.</value>
     </data>
-    <data name="ChangeLanguageAlertOk" xml:space="preserve">
+    <data name="InfoAlert_ChangeLanguage_Ok" xml:space="preserve">
         <value>Ok</value>
     </data>
     <data name="ErrorAlert_Title" xml:space="preserve">
@@ -165,22 +165,22 @@
     <data name="ErrorAlert_Description" xml:space="preserve">
         <value>An error occurred</value>
     </data>
-    <data name="ErrorAlert_GetCategoryInfo" xml:space="preserve">
+    <data name="CommonError_GetCategoryInfo" xml:space="preserve">
         <value>Cannot get category info</value>
     </data>
-    <data name="ErrorAlert_ShowFilteredTransactions" xml:space="preserve">
+    <data name="CommonError_ShowFilteredTransactions" xml:space="preserve">
         <value>Cannot show filtered transactions</value>
     </data>
-    <data name="ErrorAlert_OpenAddCategoryPage" xml:space="preserve">
+    <data name="CommonError_OpenAddCategoryPage" xml:space="preserve">
         <value>Cannot open category adding page</value>
     </data>
-    <data name="ErrorAlert_OpenAddTransactionPage" xml:space="preserve">
+    <data name="CommonError_OpenAddTransactionPage" xml:space="preserve">
         <value>Cannot open transaction adding page</value>
     </data>
-    <data name="ErrorAlert_InternalErrorTryAgain" xml:space="preserve">
+    <data name="CommonError_InternalErrorTryAgain" xml:space="preserve">
         <value>An internal error occurred. Try again</value>
     </data>
-    <data name="ErrorAlert_FindTransactionToDelete" xml:space="preserve">
+    <data name="CommonError_FindTransactionToDelete" xml:space="preserve">
         <value>Cannot find transaction to delete</value>
     </data>
     <data name="CommonError_PlannedAmountNumber" xml:space="preserve">
@@ -203,5 +203,38 @@
     </data>
     <data name="CommonError_TransactionType" xml:space="preserve">
         <value>Invalid transaction type</value>
+    </data>
+    <data name="Pages_Language" xml:space="preserve">
+        <value>Language</value>
+    </data>
+    <data name="Pages_Categories" xml:space="preserve">
+        <value>Categories</value>
+    </data>
+    <data name="Pages_Theme" xml:space="preserve">
+        <value>Theme</value>
+    </data>
+    <data name="Home_Categories" xml:space="preserve">
+        <value>Categories expenses</value>
+    </data>
+    <data name="AddTransaction_Main" xml:space="preserve">
+        <value>Main</value>
+    </data>
+    <data name="AddTransaction_Secondary" xml:space="preserve">
+        <value>Secondary</value>
+    </data>
+    <data name="AddTransaction_Saved" xml:space="preserve">
+        <value>Saved</value>
+    </data>
+    <data name="Transactions_Main" xml:space="preserve">
+        <value>Main</value>
+    </data>
+    <data name="Transactions_Secondary" xml:space="preserve">
+        <value>Secondary</value>
+    </data>
+    <data name="Transactions_Saved" xml:space="preserve">
+        <value>Saved</value>
+    </data>
+    <data name="Transactions_Income" xml:space="preserve">
+        <value>Income</value>
     </data>
 </root>

--- a/src/Profitocracy.Mobile/Resources/Strings/AppResources.ru.Designer.cs
+++ b/src/Profitocracy.Mobile/Resources/Strings/AppResources.ru.Designer.cs
@@ -45,279 +45,279 @@ namespace Profitocracy.Mobile.Resources.Strings {
             }
         }
         
-        internal static string CreateFirstProfile {
+        internal static string Setup_FirstProfile {
             get {
-                return ResourceManager.GetString("CreateFirstProfile", resourceCulture);
+                return ResourceManager.GetString("Setup_FirstProfile", resourceCulture);
             }
         }
         
-        internal static string Home {
+        internal static string Pages_Home {
             get {
-                return ResourceManager.GetString("Home", resourceCulture);
+                return ResourceManager.GetString("Pages_Home", resourceCulture);
             }
         }
         
-        internal static string Balance {
+        internal static string Home_Balance {
             get {
-                return ResourceManager.GetString("Balance", resourceCulture);
+                return ResourceManager.GetString("Home_Balance", resourceCulture);
             }
         }
         
-        internal static string DailyAmounts {
+        internal static string Home_DailyAmounts {
             get {
-                return ResourceManager.GetString("DailyAmounts", resourceCulture);
+                return ResourceManager.GetString("Home_DailyAmounts", resourceCulture);
             }
         }
         
-        internal static string FromActualBalance {
+        internal static string Home_FromActualBalance {
             get {
-                return ResourceManager.GetString("FromActualBalance", resourceCulture);
+                return ResourceManager.GetString("Home_FromActualBalance", resourceCulture);
             }
         }
         
-        internal static string FromInitialBalance {
+        internal static string Home_FromInitialBalance {
             get {
-                return ResourceManager.GetString("FromInitialBalance", resourceCulture);
+                return ResourceManager.GetString("Home_FromInitialBalance", resourceCulture);
             }
         }
         
-        internal static string SpendingTypes {
+        internal static string Home_SpendingTypes {
             get {
-                return ResourceManager.GetString("SpendingTypes", resourceCulture);
+                return ResourceManager.GetString("Home_SpendingTypes", resourceCulture);
             }
         }
         
-        internal static string Categories {
+        internal static string Settings_Categories {
             get {
-                return ResourceManager.GetString("Categories", resourceCulture);
+                return ResourceManager.GetString("Settings_Categories", resourceCulture);
             }
         }
         
-        internal static string Main {
+        internal static string Home_Main {
             get {
-                return ResourceManager.GetString("Main", resourceCulture);
+                return ResourceManager.GetString("Home_Main", resourceCulture);
             }
         }
         
-        internal static string Saved {
+        internal static string Home_Saved {
             get {
-                return ResourceManager.GetString("Saved", resourceCulture);
+                return ResourceManager.GetString("Home_Saved", resourceCulture);
             }
         }
         
-        internal static string Secondary {
+        internal static string Home_Secondary {
             get {
-                return ResourceManager.GetString("Secondary", resourceCulture);
+                return ResourceManager.GetString("Home_Secondary", resourceCulture);
             }
         }
         
-        internal static string ThereIsNoCategories {
+        internal static string Home_NoCategories {
             get {
-                return ResourceManager.GetString("ThereIsNoCategories", resourceCulture);
+                return ResourceManager.GetString("Home_NoCategories", resourceCulture);
             }
         }
         
-        internal static string SavedBalance {
+        internal static string Home_SavedBalance {
             get {
-                return ResourceManager.GetString("SavedBalance", resourceCulture);
+                return ResourceManager.GetString("Home_SavedBalance", resourceCulture);
             }
         }
         
-        internal static string GoToExpenses {
+        internal static string Setup_GoToExpenses {
             get {
-                return ResourceManager.GetString("GoToExpenses", resourceCulture);
+                return ResourceManager.GetString("Setup_GoToExpenses", resourceCulture);
             }
         }
         
-        internal static string InitialBalance {
+        internal static string Setup_InitialBalance {
             get {
-                return ResourceManager.GetString("InitialBalance", resourceCulture);
+                return ResourceManager.GetString("Setup_InitialBalance", resourceCulture);
             }
         }
         
-        internal static string ProfileName {
+        internal static string Setup_ProfileName {
             get {
-                return ResourceManager.GetString("ProfileName", resourceCulture);
+                return ResourceManager.GetString("Setup_ProfileName", resourceCulture);
             }
         }
         
-        internal static string Transactions {
+        internal static string Pages_Transactions {
             get {
-                return ResourceManager.GetString("Transactions", resourceCulture);
+                return ResourceManager.GetString("Pages_Transactions", resourceCulture);
             }
         }
         
-        internal static string Income {
+        internal static string AddTransaction_Income {
             get {
-                return ResourceManager.GetString("Income", resourceCulture);
+                return ResourceManager.GetString("AddTransaction_Income", resourceCulture);
             }
         }
         
-        internal static string Settings {
+        internal static string Pages_Settings {
             get {
-                return ResourceManager.GetString("Settings", resourceCulture);
+                return ResourceManager.GetString("Pages_Settings", resourceCulture);
             }
         }
         
-        internal static string AddNewTransaction {
+        internal static string Pages_NewTransaction {
             get {
-                return ResourceManager.GetString("AddNewTransaction", resourceCulture);
+                return ResourceManager.GetString("Pages_NewTransaction", resourceCulture);
             }
         }
         
-        internal static string Amount {
+        internal static string AddTransaction_Amount {
             get {
-                return ResourceManager.GetString("Amount", resourceCulture);
+                return ResourceManager.GetString("AddTransaction_Amount", resourceCulture);
             }
         }
         
-        internal static string Category {
+        internal static string AddTransaction_Category {
             get {
-                return ResourceManager.GetString("Category", resourceCulture);
+                return ResourceManager.GetString("AddTransaction_Category", resourceCulture);
             }
         }
         
-        internal static string Date {
+        internal static string AddTransaction_Date {
             get {
-                return ResourceManager.GetString("Date", resourceCulture);
+                return ResourceManager.GetString("AddTransaction_Date", resourceCulture);
             }
         }
         
-        internal static string Description {
+        internal static string AddTransaction_Description {
             get {
-                return ResourceManager.GetString("Description", resourceCulture);
+                return ResourceManager.GetString("AddTransaction_Description", resourceCulture);
             }
         }
         
-        internal static string Expense {
+        internal static string AddTransaction_Expense {
             get {
-                return ResourceManager.GetString("Expense", resourceCulture);
+                return ResourceManager.GetString("AddTransaction_Expense", resourceCulture);
             }
         }
         
-        internal static string SaveTransaction {
+        internal static string AddTransaction_SaveTransaction {
             get {
-                return ResourceManager.GetString("SaveTransaction", resourceCulture);
+                return ResourceManager.GetString("AddTransaction_SaveTransaction", resourceCulture);
             }
         }
         
-        internal static string Application {
+        internal static string Settings_Application {
             get {
-                return ResourceManager.GetString("Application", resourceCulture);
+                return ResourceManager.GetString("Settings_Application", resourceCulture);
             }
         }
         
-        internal static string General {
+        internal static string Settings_General {
             get {
-                return ResourceManager.GetString("General", resourceCulture);
+                return ResourceManager.GetString("Settings_General", resourceCulture);
             }
         }
         
-        internal static string Language {
+        internal static string Settings_Language {
             get {
-                return ResourceManager.GetString("Language", resourceCulture);
+                return ResourceManager.GetString("Settings_Language", resourceCulture);
             }
         }
         
-        internal static string Profiles {
+        internal static string Settings_Profiles {
             get {
-                return ResourceManager.GetString("Profiles", resourceCulture);
+                return ResourceManager.GetString("Settings_Profiles", resourceCulture);
             }
         }
         
-        internal static string Theme {
+        internal static string Settings_Theme {
             get {
-                return ResourceManager.GetString("Theme", resourceCulture);
+                return ResourceManager.GetString("Settings_Theme", resourceCulture);
             }
         }
         
-        internal static string AddNewCategory {
+        internal static string Pages_NewCategory {
             get {
-                return ResourceManager.GetString("AddNewCategory", resourceCulture);
+                return ResourceManager.GetString("Pages_NewCategory", resourceCulture);
             }
         }
         
-        internal static string CategoryName {
+        internal static string AddCategory_CategoryName {
             get {
-                return ResourceManager.GetString("CategoryName", resourceCulture);
+                return ResourceManager.GetString("AddCategory_CategoryName", resourceCulture);
             }
         }
         
-        internal static string NoLimits {
+        internal static string Categories_NoLimits {
             get {
-                return ResourceManager.GetString("NoLimits", resourceCulture);
+                return ResourceManager.GetString("Categories_NoLimits", resourceCulture);
             }
         }
         
-        internal static string PlannedAmount {
+        internal static string AddCategory_PlannedAmount {
             get {
-                return ResourceManager.GetString("PlannedAmount", resourceCulture);
+                return ResourceManager.GetString("AddCategory_PlannedAmount", resourceCulture);
             }
         }
         
-        internal static string SaveCategory {
+        internal static string AddCategory_SaveCategory {
             get {
-                return ResourceManager.GetString("SaveCategory", resourceCulture);
+                return ResourceManager.GetString("AddCategory_SaveCategory", resourceCulture);
             }
         }
         
-        internal static string SpecifyPlannedAmount {
+        internal static string AddCategory_SpecifyPlannedAmount {
             get {
-                return ResourceManager.GetString("SpecifyPlannedAmount", resourceCulture);
+                return ResourceManager.GetString("AddCategory_SpecifyPlannedAmount", resourceCulture);
             }
         }
         
-        internal static string DateRange {
+        internal static string Transactions_DateRange {
             get {
-                return ResourceManager.GetString("DateRange", resourceCulture);
+                return ResourceManager.GetString("Transactions_DateRange", resourceCulture);
             }
         }
         
-        internal static string LightThemeText {
+        internal static string ThemeSettings_LightTheme {
             get {
-                return ResourceManager.GetString("LightThemeText", resourceCulture);
+                return ResourceManager.GetString("ThemeSettings_LightTheme", resourceCulture);
             }
         }
         
-        internal static string DarkThemeText {
+        internal static string ThemeSettings_Dark {
             get {
-                return ResourceManager.GetString("DarkThemeText", resourceCulture);
+                return ResourceManager.GetString("ThemeSettings_Dark", resourceCulture);
             }
         }
         
-        internal static string SystemThemeText {
+        internal static string ThemeSettings_System {
             get {
-                return ResourceManager.GetString("SystemThemeText", resourceCulture);
+                return ResourceManager.GetString("ThemeSettings_System", resourceCulture);
             }
         }
         
-        internal static string EnglishLanguage {
+        internal static string Languages_English {
             get {
-                return ResourceManager.GetString("EnglishLanguage", resourceCulture);
+                return ResourceManager.GetString("Languages_English", resourceCulture);
             }
         }
         
-        internal static string RussianLanguage {
+        internal static string Languages_Russian {
             get {
-                return ResourceManager.GetString("RussianLanguage", resourceCulture);
+                return ResourceManager.GetString("Languages_Russian", resourceCulture);
             }
         }
         
-        internal static string ChangeLanguageAlertMessage {
+        internal static string InfoAlert_ChangeLanguage_Message {
             get {
-                return ResourceManager.GetString("ChangeLanguageAlertMessage", resourceCulture);
+                return ResourceManager.GetString("InfoAlert_ChangeLanguage_Message", resourceCulture);
             }
         }
         
-        internal static string ChangeLanguageAlertTitle {
+        internal static string InfoAlert_ChangeLanguage_Title {
             get {
-                return ResourceManager.GetString("ChangeLanguageAlertTitle", resourceCulture);
+                return ResourceManager.GetString("InfoAlert_ChangeLanguage_Title", resourceCulture);
             }
         }
         
-        internal static string ChangeLanguageAlertOk {
+        internal static string InfoAlert_ChangeLanguage_Ok {
             get {
-                return ResourceManager.GetString("ChangeLanguageAlertOk", resourceCulture);
+                return ResourceManager.GetString("InfoAlert_ChangeLanguage_Ok", resourceCulture);
             }
         }
         
@@ -339,39 +339,39 @@ namespace Profitocracy.Mobile.Resources.Strings {
             }
         }
         
-        internal static string ErrorAlert_GetCategoryInfo {
+        internal static string CommonError_GetCategoryInfo {
             get {
-                return ResourceManager.GetString("ErrorAlert_GetCategoryInfo", resourceCulture);
+                return ResourceManager.GetString("CommonError_GetCategoryInfo", resourceCulture);
             }
         }
         
-        internal static string ErrorAlert_ShowFilteredTransactions {
+        internal static string CommonError_ShowFilteredTransactions {
             get {
-                return ResourceManager.GetString("ErrorAlert_ShowFilteredTransactions", resourceCulture);
+                return ResourceManager.GetString("CommonError_ShowFilteredTransactions", resourceCulture);
             }
         }
         
-        internal static string ErrorAlert_OpenAddCategoryPage {
+        internal static string CommonError_OpenAddCategoryPage {
             get {
-                return ResourceManager.GetString("ErrorAlert_OpenAddCategoryPage", resourceCulture);
+                return ResourceManager.GetString("CommonError_OpenAddCategoryPage", resourceCulture);
             }
         }
         
-        internal static string ErrorAlert_OpenAddTransactionPage {
+        internal static string CommonError_OpenAddTransactionPage {
             get {
-                return ResourceManager.GetString("ErrorAlert_OpenAddTransactionPage", resourceCulture);
+                return ResourceManager.GetString("CommonError_OpenAddTransactionPage", resourceCulture);
             }
         }
         
-        internal static string ErrorAlert_InternalErrorTryAgain {
+        internal static string CommonError_InternalErrorTryAgain {
             get {
-                return ResourceManager.GetString("ErrorAlert_InternalErrorTryAgain", resourceCulture);
+                return ResourceManager.GetString("CommonError_InternalErrorTryAgain", resourceCulture);
             }
         }
         
-        internal static string ErrorAlert_FindTransactionToDelete {
+        internal static string CommonError_FindTransactionToDelete {
             get {
-                return ResourceManager.GetString("ErrorAlert_FindTransactionToDelete", resourceCulture);
+                return ResourceManager.GetString("CommonError_FindTransactionToDelete", resourceCulture);
             }
         }
         
@@ -414,6 +414,72 @@ namespace Profitocracy.Mobile.Resources.Strings {
         internal static string CommonError_TransactionType {
             get {
                 return ResourceManager.GetString("CommonError_TransactionType", resourceCulture);
+            }
+        }
+        
+        internal static string Pages_Language {
+            get {
+                return ResourceManager.GetString("Pages_Language", resourceCulture);
+            }
+        }
+        
+        internal static string Pages_Categories {
+            get {
+                return ResourceManager.GetString("Pages_Categories", resourceCulture);
+            }
+        }
+        
+        internal static string Pages_Theme {
+            get {
+                return ResourceManager.GetString("Pages_Theme", resourceCulture);
+            }
+        }
+        
+        internal static string Home_Categories {
+            get {
+                return ResourceManager.GetString("Home_Categories", resourceCulture);
+            }
+        }
+        
+        internal static string AddTransaction_Secondary {
+            get {
+                return ResourceManager.GetString("AddTransaction_Secondary", resourceCulture);
+            }
+        }
+        
+        internal static string AddTransaction_Saved {
+            get {
+                return ResourceManager.GetString("AddTransaction_Saved", resourceCulture);
+            }
+        }
+        
+        internal static string AddTransaction_Main {
+            get {
+                return ResourceManager.GetString("AddTransaction_Main", resourceCulture);
+            }
+        }
+        
+        internal static string Transactions_Income {
+            get {
+                return ResourceManager.GetString("Transactions_Income", resourceCulture);
+            }
+        }
+        
+        internal static string Transactions_Main {
+            get {
+                return ResourceManager.GetString("Transactions_Main", resourceCulture);
+            }
+        }
+        
+        internal static string Transactions_Saved {
+            get {
+                return ResourceManager.GetString("Transactions_Saved", resourceCulture);
+            }
+        }
+        
+        internal static string Transactions_Secondary {
+            get {
+                return ResourceManager.GetString("Transactions_Secondary", resourceCulture);
             }
         }
     }

--- a/src/Profitocracy.Mobile/Resources/Strings/AppResources.ru.Designer.cs
+++ b/src/Profitocracy.Mobile/Resources/Strings/AppResources.ru.Designer.cs
@@ -69,15 +69,15 @@ namespace Profitocracy.Mobile.Resources.Strings {
             }
         }
         
-        internal static string Home_FromActualBalance {
+        internal static string Home_TodayBalance {
             get {
-                return ResourceManager.GetString("Home_FromActualBalance", resourceCulture);
+                return ResourceManager.GetString("Home_TodayBalance", resourceCulture);
             }
         }
         
-        internal static string Home_FromInitialBalance {
+        internal static string Home_TomorrowBalance {
             get {
-                return ResourceManager.GetString("Home_FromInitialBalance", resourceCulture);
+                return ResourceManager.GetString("Home_TomorrowBalance", resourceCulture);
             }
         }
         

--- a/src/Profitocracy.Mobile/Resources/Strings/AppResources.ru.resx
+++ b/src/Profitocracy.Mobile/Resources/Strings/AppResources.ru.resx
@@ -18,142 +18,142 @@
     <resheader name="writer">
         <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
     </resheader>
-    <data name="CreateFirstProfile" xml:space="preserve">
-        <value>Создайте первый профиль</value>
+    <data name="Setup_FirstProfile" xml:space="preserve">
+        <value>Первый профиль</value>
     </data>
-    <data name="Home" xml:space="preserve">
+    <data name="Pages_Home" xml:space="preserve">
         <value>Главная</value>
     </data>
-    <data name="Balance" xml:space="preserve">
+    <data name="Home_Balance" xml:space="preserve">
         <value>Баланс</value>
     </data>
-    <data name="DailyAmounts" xml:space="preserve">
+    <data name="Home_DailyAmounts" xml:space="preserve">
         <value>Дневные расходы</value>
     </data>
-    <data name="FromActualBalance" xml:space="preserve">
+    <data name="Home_FromActualBalance" xml:space="preserve">
         <value>От текущего баланса</value>
     </data>
-    <data name="FromInitialBalance" xml:space="preserve">
+    <data name="Home_FromInitialBalance" xml:space="preserve">
         <value>От начального баланса</value>
     </data>
-    <data name="SpendingTypes" xml:space="preserve">
+    <data name="Home_SpendingTypes" xml:space="preserve">
         <value>Типы расходов</value>
     </data>
-    <data name="Categories" xml:space="preserve">
+    <data name="Settings_Categories" xml:space="preserve">
         <value>Категории</value>
     </data>
-    <data name="Main" xml:space="preserve">
+    <data name="Home_Main" xml:space="preserve">
         <value>Основные</value>
     </data>
-    <data name="Saved" xml:space="preserve">
+    <data name="Home_Saved" xml:space="preserve">
         <value>Отложенные</value>
     </data>
-    <data name="Secondary" xml:space="preserve">
+    <data name="Home_Secondary" xml:space="preserve">
         <value>Второстепенные</value>
     </data>
-    <data name="ThereIsNoCategories" xml:space="preserve">
+    <data name="Home_NoCategories" xml:space="preserve">
         <value>Пока что нет категорий</value>
     </data>
-    <data name="SavedBalance" xml:space="preserve">
+    <data name="Home_SavedBalance" xml:space="preserve">
         <value>Отложено</value>
     </data>
-    <data name="GoToExpenses" xml:space="preserve">
+    <data name="Setup_GoToExpenses" xml:space="preserve">
         <value>Перейти к расходам</value>
     </data>
-    <data name="InitialBalance" xml:space="preserve">
+    <data name="Setup_InitialBalance" xml:space="preserve">
         <value>Начальный баланс</value>
     </data>
-    <data name="ProfileName" xml:space="preserve">
+    <data name="Setup_ProfileName" xml:space="preserve">
         <value>Название профиля</value>
     </data>
-    <data name="Transactions" xml:space="preserve">
+    <data name="Pages_Transactions" xml:space="preserve">
         <value>Транзакции</value>
     </data>
-    <data name="Income" xml:space="preserve">
+    <data name="AddTransaction_Income" xml:space="preserve">
         <value>Доход</value>
     </data>
-    <data name="Settings" xml:space="preserve">
+    <data name="Pages_Settings" xml:space="preserve">
         <value>Настройки</value>
     </data>
-    <data name="AddNewTransaction" xml:space="preserve">
+    <data name="Pages_NewTransaction" xml:space="preserve">
         <value>Новая транзакция</value>
     </data>
-    <data name="Amount" xml:space="preserve">
+    <data name="AddTransaction_Amount" xml:space="preserve">
         <value>Сумма</value>
     </data>
-    <data name="Category" xml:space="preserve">
+    <data name="AddTransaction_Category" xml:space="preserve">
         <value>Категория</value>
     </data>
-    <data name="Date" xml:space="preserve">
+    <data name="AddTransaction_Date" xml:space="preserve">
         <value>Дата</value>
     </data>
-    <data name="Description" xml:space="preserve">
+    <data name="AddTransaction_Description" xml:space="preserve">
         <value>Описание</value>
     </data>
-    <data name="Expense" xml:space="preserve">
+    <data name="AddTransaction_Expense" xml:space="preserve">
         <value>Расход</value>
     </data>
-    <data name="SaveTransaction" xml:space="preserve">
+    <data name="AddTransaction_SaveTransaction" xml:space="preserve">
         <value>Сохранить транзакцию</value>
     </data>
-    <data name="Application" xml:space="preserve">
+    <data name="Settings_Application" xml:space="preserve">
         <value>Настройки приложения</value>
     </data>
-    <data name="General" xml:space="preserve">
+    <data name="Settings_General" xml:space="preserve">
         <value>Основные</value>
     </data>
-    <data name="Language" xml:space="preserve">
+    <data name="Settings_Language" xml:space="preserve">
         <value>Язык</value>
     </data>
-    <data name="Profiles" xml:space="preserve">
+    <data name="Settings_Profiles" xml:space="preserve">
         <value>Профили</value>
     </data>
-    <data name="Theme" xml:space="preserve">
+    <data name="Settings_Theme" xml:space="preserve">
         <value>Тема</value>
     </data>
-    <data name="AddNewCategory" xml:space="preserve">
+    <data name="Pages_NewCategory" xml:space="preserve">
         <value>Новая категория</value>
     </data>
-    <data name="CategoryName" xml:space="preserve">
+    <data name="AddCategory_CategoryName" xml:space="preserve">
         <value>Название категории</value>
     </data>
-    <data name="NoLimits" xml:space="preserve">
+    <data name="Categories_NoLimits" xml:space="preserve">
         <value>Без ограничений</value>
     </data>
-    <data name="PlannedAmount" xml:space="preserve">
+    <data name="AddCategory_PlannedAmount" xml:space="preserve">
         <value>Планируемая сумма</value>
     </data>
-    <data name="SaveCategory" xml:space="preserve">
+    <data name="AddCategory_SaveCategory" xml:space="preserve">
         <value>Сохранить категорию</value>
     </data>
-    <data name="SpecifyPlannedAmount" xml:space="preserve">
+    <data name="AddCategory_SpecifyPlannedAmount" xml:space="preserve">
         <value>Указать планируемую сумму</value>
     </data>
-    <data name="DateRange" xml:space="preserve">
+    <data name="Transactions_DateRange" xml:space="preserve">
         <value>Отфильтровать по дате</value>
     </data>
-    <data name="LightThemeText" xml:space="preserve">
+    <data name="ThemeSettings_LightTheme" xml:space="preserve">
         <value>Светлая</value>
     </data>
-    <data name="DarkThemeText" xml:space="preserve">
+    <data name="ThemeSettings_Dark" xml:space="preserve">
         <value>Темная</value>
     </data>
-    <data name="SystemThemeText" xml:space="preserve">
+    <data name="ThemeSettings_System" xml:space="preserve">
         <value>Системная</value>
     </data>
-    <data name="EnglishLanguage" xml:space="preserve">
+    <data name="Languages_English" xml:space="preserve">
         <value>Английский</value>
     </data>
-    <data name="RussianLanguage" xml:space="preserve">
+    <data name="Languages_Russian" xml:space="preserve">
         <value>Русский</value>
     </data>
-    <data name="ChangeLanguageAlertMessage" xml:space="preserve">
+    <data name="InfoAlert_ChangeLanguage_Message" xml:space="preserve">
         <value>Чтобы изменения вступили в силу, требуется перезапустить приложение.</value>
     </data>
-    <data name="ChangeLanguageAlertTitle" xml:space="preserve">
+    <data name="InfoAlert_ChangeLanguage_Title" xml:space="preserve">
         <value>Предупреждение</value>
     </data>
-    <data name="ChangeLanguageAlertOk" xml:space="preserve">
+    <data name="InfoAlert_ChangeLanguage_Ok" xml:space="preserve">
         <value>Понятно</value>
     </data>
     <data name="ErrorAlert_Title" xml:space="preserve">
@@ -165,22 +165,22 @@
     <data name="ErrorAlert_Description" xml:space="preserve">
         <value>Возникла ошибка</value>
     </data>
-    <data name="ErrorAlert_GetCategoryInfo" xml:space="preserve">
+    <data name="CommonError_GetCategoryInfo" xml:space="preserve">
         <value>Не удалось получить информацию по категории</value>
     </data>
-    <data name="ErrorAlert_ShowFilteredTransactions" xml:space="preserve">
+    <data name="CommonError_ShowFilteredTransactions" xml:space="preserve">
         <value>Не удалось открыть отфильтрованные транзакции</value>
     </data>
-    <data name="ErrorAlert_OpenAddCategoryPage" xml:space="preserve">
+    <data name="CommonError_OpenAddCategoryPage" xml:space="preserve">
         <value>Не удалось открыть страницу создания новой категории</value>
     </data>
-    <data name="ErrorAlert_OpenAddTransactionPage" xml:space="preserve">
+    <data name="CommonError_OpenAddTransactionPage" xml:space="preserve">
         <value>Не удалось открыть страницу создания транзакции</value>
     </data>
-    <data name="ErrorAlert_InternalErrorTryAgain" xml:space="preserve">
+    <data name="CommonError_InternalErrorTryAgain" xml:space="preserve">
         <value>Произошла внутренняя ошибка. Попробуйте снова</value>
     </data>
-    <data name="ErrorAlert_FindTransactionToDelete" xml:space="preserve">
+    <data name="CommonError_FindTransactionToDelete" xml:space="preserve">
         <value>Не удалось найти транзакцию для удаления</value>
     </data>
     <data name="CommonError_PlannedAmountNumber" xml:space="preserve">
@@ -203,5 +203,38 @@
     </data>
     <data name="CommonError_TransactionType" xml:space="preserve">
         <value>Неверный тип транзакции</value>
+    </data>
+    <data name="Pages_Language" xml:space="preserve">
+        <value>Язык</value>
+    </data>
+    <data name="Pages_Categories" xml:space="preserve">
+        <value>Категории</value>
+    </data>
+    <data name="Pages_Theme" xml:space="preserve">
+        <value>Тема</value>
+    </data>
+    <data name="Home_Categories" xml:space="preserve">
+        <value>Расходы по категориям</value>
+    </data>
+    <data name="AddTransaction_Secondary" xml:space="preserve">
+        <value>Второстепенные</value>
+    </data>
+    <data name="AddTransaction_Saved" xml:space="preserve">
+        <value>Отложенные</value>
+    </data>
+    <data name="AddTransaction_Main" xml:space="preserve">
+        <value>Основные</value>
+    </data>
+    <data name="Transactions_Income" xml:space="preserve">
+        <value>Доход</value>
+    </data>
+    <data name="Transactions_Main" xml:space="preserve">
+        <value>Основные</value>
+    </data>
+    <data name="Transactions_Saved" xml:space="preserve">
+        <value>Отложенные</value>
+    </data>
+    <data name="Transactions_Secondary" xml:space="preserve">
+        <value>Второстепенные</value>
     </data>
 </root>

--- a/src/Profitocracy.Mobile/Resources/Strings/AppResources.ru.resx
+++ b/src/Profitocracy.Mobile/Resources/Strings/AppResources.ru.resx
@@ -30,11 +30,11 @@
     <data name="Home_DailyAmounts" xml:space="preserve">
         <value>Дневные расходы</value>
     </data>
-    <data name="Home_FromActualBalance" xml:space="preserve">
-        <value>От текущего баланса</value>
+    <data name="Home_TodayBalance" xml:space="preserve">
+        <value>Сегодня</value>
     </data>
-    <data name="Home_FromInitialBalance" xml:space="preserve">
-        <value>От начального баланса</value>
+    <data name="Home_TomorrowBalance" xml:space="preserve">
+        <value>Завтра</value>
     </data>
     <data name="Home_SpendingTypes" xml:space="preserve">
         <value>Типы расходов</value>

--- a/src/Profitocracy.Mobile/Utils/NumberUtils.cs
+++ b/src/Profitocracy.Mobile/Utils/NumberUtils.cs
@@ -5,10 +5,24 @@ namespace Profitocracy.Mobile.Utils;
 /// </summary>
 public static class NumberUtils
 {
-    public static decimal RoundDecimal(decimal? num, int decimals = 2)
-    {
-        return num is null 
+    /// <summary>
+    /// Round decimal to a specified amount of decimals.
+    /// </summary>
+    /// <param name="num">Number to round</param>
+    /// <param name="decimals">Decimals places</param>
+    /// <returns>Rounded decimal if num is not null, otherwise, zero</returns>
+    public static decimal RoundDecimal(decimal? num, int decimals = 2) 
+        => num is null 
             ? decimal.Zero 
             : Math.Round((decimal)num, decimals);
-    }
+
+    /// <summary>
+    /// Get ratio between two decimal numbers.
+    /// Ratio is represented with float value.
+    /// </summary>
+    /// <param name="val1">First value</param>
+    /// <param name="val2">Second value</param>
+    /// <returns>Ratio between two decimal numbers</returns>
+    public static float GetFloatRatio(decimal val1, decimal val2) 
+        => (float)(val1 / val2);
 }

--- a/src/Profitocracy.Mobile/Views/Home/HomePage.xaml
+++ b/src/Profitocracy.Mobile/Views/Home/HomePage.xaml
@@ -6,7 +6,7 @@
                               xmlns:categories="clr-namespace:Profitocracy.Mobile.Models.Categories"
                               xmlns:abstractions="clr-namespace:Profitocracy.Mobile.Abstractions"
                               x:Class="Profitocracy.Mobile.Views.Home.HomePage"
-                              Title="{x:Static resx:AppResources.Home}"
+                              Title="{x:Static resx:AppResources.Pages_Home}"
                               BackgroundColor="{AppThemeBinding Light={StaticResource LightBackground}, Dark={StaticResource DarkBackground}}"
                               NavigatedTo="HomePage_OnNavigated">
     <RefreshView IsRefreshing="{Binding IsRefreshing}"
@@ -38,7 +38,7 @@
                         <FlexLayout JustifyContent="SpaceBetween"
                                     Margin="0, 16, 0, 0">
                             <Label Style="{StaticResource ProfileExpenseCardSubtitle}"
-                                   Text="{x:Static resx:AppResources.Balance}"/>
+                                   Text="{x:Static resx:AppResources.Home_Balance}"/>
                             <Label Style="{StaticResource ProfileExpenseCardBalance}"
                                    Text="{Binding Balance}"/>
                         </FlexLayout>
@@ -55,7 +55,7 @@
                         <FlexLayout JustifyContent="SpaceBetween"
                                     Margin="0, 16, 0, 0">
                             <Label Style="{StaticResource ProfileExpenseCardSubtitle}" 
-                                   Text="{x:Static resx:AppResources.SavedBalance}" />
+                                   Text="{x:Static resx:AppResources.Home_SavedBalance}" />
                             <Label Style="{StaticResource ProfileExpenseCardBalance}"
                                    Text="{Binding TotalSavedAmount}" />
                         </FlexLayout>
@@ -66,7 +66,7 @@
                         Margin="0, 16, 0, 0">
                     <StackLayout>
                         <Label Style="{StaticResource ExpenseCardTitle}"
-                               Text="{x:Static resx:AppResources.DailyAmounts}"/>
+                               Text="{x:Static resx:AppResources.Home_DailyAmounts}"/>
                         <Grid Margin="0, 16, 0, 0">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition />
@@ -75,7 +75,7 @@
                             <StackLayout Grid.Column="0"
                                          Padding="0, 0, 8, 0">
                                 <Label Style="{StaticResource ExpenseCardSubtitle}"
-                                       Text="{x:Static resx:AppResources.FromInitialBalance}"/>
+                                       Text="{x:Static resx:AppResources.Home_FromInitialBalance}"/>
                                 <ProgressBar Style="{StaticResource ExpenseCardProgressBar}"
                                              Margin="0,8,0,0"
                                              Progress="{Binding DailyFromInitialRatio}"/>
@@ -89,7 +89,7 @@
                             <StackLayout Grid.Column="1"
                                          Padding="8, 0, 0, 0">
                                 <Label Style="{StaticResource ExpenseCardSubtitle}"
-                                       Text="{x:Static resx:AppResources.FromActualBalance}"/>
+                                       Text="{x:Static resx:AppResources.Home_FromActualBalance}"/>
                                 <ProgressBar Style="{StaticResource ExpenseCardProgressBar}"
                                              Margin="0,8,0,0"
                                              Progress="{Binding DailyFromActualRatio}"/>
@@ -108,7 +108,7 @@
                         Margin="0, 16, 0, 0">
                     <StackLayout>
                         <Label Style="{StaticResource ExpenseCardTitle}"
-                               Text="{x:Static resx:AppResources.SpendingTypes}"/>
+                               Text="{x:Static resx:AppResources.Home_SpendingTypes}"/>
                             
                         <StackLayout x:Name="MainExpenses"
                                      Margin="0,16,0,0">
@@ -116,7 +116,7 @@
                                 <TapGestureRecognizer Tapped="MainSpendingTypeLayout_OnTapped" />
                             </StackLayout.GestureRecognizers>
                             <Label Style="{StaticResource ExpenseCardSubtitle}"
-                                   Text="{x:Static resx:AppResources.Main}"/>
+                                   Text="{x:Static resx:AppResources.Home_Main}"/>
                             <ProgressBar Style="{StaticResource ExpenseCardProgressBar}"
                                          Margin="0,8,0,0"
                                          Progress="{Binding MainExpensesRatio}"/>
@@ -134,7 +134,7 @@
                                 <TapGestureRecognizer Tapped="SecondarySpendingTypeLayout_OnTapped" />
                             </StackLayout.GestureRecognizers>
                             <Label Style="{StaticResource ExpenseCardSubtitle}"
-                                   Text="{x:Static resx:AppResources.Secondary}"/>
+                                   Text="{x:Static resx:AppResources.Home_Secondary}"/>
                             <ProgressBar Style="{StaticResource ExpenseCardProgressBar}"
                                          Margin="0,8,0,0"
                                          Progress="{Binding SecondaryExpensesRatio}"/>
@@ -152,7 +152,7 @@
                                 <TapGestureRecognizer Tapped="SavedSpendingTypeLayout_OnTapped" />
                             </StackLayout.GestureRecognizers>
                             <Label Style="{StaticResource ExpenseCardSubtitle}"
-                                   Text="{x:Static resx:AppResources.Saved}"/>
+                                   Text="{x:Static resx:AppResources.Home_Saved}"/>
                             <ProgressBar Style="{StaticResource ExpenseCardProgressBar}"
                                          Margin="0,8,0,0"
                                          Progress="{Binding SavedRatio}"/>
@@ -170,11 +170,11 @@
                         Margin="0, 16, 0, 0">
                     <StackLayout>
                         <Label Style="{StaticResource ExpenseCardTitle}"
-                               Text="{x:Static resx:AppResources.Categories}"/>
+                               Text="{x:Static resx:AppResources.Home_Categories}"/>
                         
                         <Label Style="{StaticResource ExpenseCardSubtitle}" 
                                IsVisible="{Binding IsDisplayNoCategories}" 
-                               Text="{x:Static resx:AppResources.ThereIsNoCategories}"
+                               Text="{x:Static resx:AppResources.Home_NoCategories}"
                                Margin="0,16,0,0"
                                HorizontalTextAlignment="Center"/> 
                         

--- a/src/Profitocracy.Mobile/Views/Home/HomePage.xaml
+++ b/src/Profitocracy.Mobile/Views/Home/HomePage.xaml
@@ -75,30 +75,24 @@
                             <StackLayout Grid.Column="0"
                                          Padding="0, 0, 8, 0">
                                 <Label Style="{StaticResource ExpenseCardSubtitle}"
-                                       Text="{x:Static resx:AppResources.Home_FromInitialBalance}"/>
+                                       Text="{x:Static resx:AppResources.Home_TodayBalance}"/>
                                 <ProgressBar Style="{StaticResource ExpenseCardProgressBar}"
                                              Margin="0,8,0,0"
-                                             Progress="{Binding DailyFromInitialRatio}"/>
+                                             Progress="{Binding TodayBalanceRatio}"/>
                                 <FlexLayout JustifyContent="SpaceBetween">
                                     <Label Style="{StaticResource ExpenseCardProgressValue}"
-                                           Text="{Binding DailyFromInitialActualAmount}"/>
+                                           Text="{Binding TodayActualAmount}"/>
                                     <Label Style="{StaticResource ExpenseCardProgressValue}"
-                                           Text="{Binding DailyFromInitialPlannedAmount}" />
+                                           Text="{Binding TodayPlannedAmount}" />
                                 </FlexLayout>
                             </StackLayout>
                             <StackLayout Grid.Column="1"
                                          Padding="8, 0, 0, 0">
                                 <Label Style="{StaticResource ExpenseCardSubtitle}"
-                                       Text="{x:Static resx:AppResources.Home_FromActualBalance}"/>
-                                <ProgressBar Style="{StaticResource ExpenseCardProgressBar}"
-                                             Margin="0,8,0,0"
-                                             Progress="{Binding DailyFromActualRatio}"/>
-                                <FlexLayout JustifyContent="SpaceBetween">
-                                    <Label Style="{StaticResource ExpenseCardProgressValue}"
-                                           Text="{Binding DailyFromActualActualAmount}"/>
-                                    <Label Style="{StaticResource ExpenseCardProgressValue}"
-                                           Text="{Binding DailyFromActualPlannedAmount}" />
-                                </FlexLayout>
+                                       Text="{x:Static resx:AppResources.Home_TomorrowBalance}"/>
+                                <Label Style="{StaticResource ExpenseCardSubtitle}"
+                                       Margin="0,8,0,0"
+                                       Text="{Binding BalanceForTomorrow}"/>
                             </StackLayout>
                         </Grid>
                     </StackLayout>

--- a/src/Profitocracy.Mobile/Views/Home/HomePage.xaml.cs
+++ b/src/Profitocracy.Mobile/Views/Home/HomePage.xaml.cs
@@ -63,14 +63,14 @@ public partial class HomePage : BaseContentPage
 	{
 		if ((sender as StackLayout)?.BindingContext is not CategoryExpenseModel category)
 		{
-			throw new Exception(AppResources.ErrorAlert_GetCategoryInfo);
+			throw new Exception(AppResources.CommonError_GetCategoryInfo);
 		}
 		
 		var filteredPage = Handler?.MauiContext?.Services.GetService<FilteredTransactionsPage>();
 
 		if (filteredPage is null)
 		{
-			throw new Exception(AppResources.ErrorAlert_ShowFilteredTransactions);
+			throw new Exception(AppResources.CommonError_ShowFilteredTransactions);
 		}
 		
 		await filteredPage.Initialize(
@@ -89,7 +89,7 @@ public partial class HomePage : BaseContentPage
 		
 		if (filteredPage is null)
 		{
-			throw new Exception(AppResources.ErrorAlert_ShowFilteredTransactions);
+			throw new Exception(AppResources.CommonError_ShowFilteredTransactions);
 		}
 		
 		await filteredPage.Initialize(

--- a/src/Profitocracy.Mobile/Views/Settings/CategoriesSettings/AddExpenseCategoryPage.xaml
+++ b/src/Profitocracy.Mobile/Views/Settings/CategoriesSettings/AddExpenseCategoryPage.xaml
@@ -13,7 +13,7 @@
             <FlexLayout Grid.Row="0"
                         JustifyContent="SpaceBetween">
                 <Label Style="{StaticResource PageTitle}"
-                       Text="{x:Static resx:AppResources.AddNewCategory}"/>
+                       Text="{x:Static resx:AppResources.Pages_NewCategory}"/>
                 <Border Style="{StaticResource CloseButton}"
                         VerticalOptions="End"
                         x:Name="CloseButton">
@@ -26,14 +26,14 @@
             </FlexLayout>
             <StackLayout Grid.Row="1">
                 <StackLayout Margin="0,32,0,0">
-                    <Label Text="{x:Static resx:AppResources.CategoryName}"/>
+                    <Label Text="{x:Static resx:AppResources.AddCategory_CategoryName}"/>
                     <Entry Margin="0,4,0,0"
                            Text="{Binding Name, Mode=TwoWay}"/>
                 </StackLayout>
                 
                 <FlexLayout Margin="0,16,0,0"
                             JustifyContent="SpaceBetween">
-                    <Label Text="{x:Static resx:AppResources.SpecifyPlannedAmount}" 
+                    <Label Text="{x:Static resx:AppResources.AddCategory_SpecifyPlannedAmount}" 
                            VerticalTextAlignment="Center"/>
                     <Switch IsToggled="{Binding IsPlannedAmountPresent, Mode=TwoWay}"/>    
                 </FlexLayout>
@@ -41,14 +41,14 @@
                 
                 <StackLayout Margin="0,16,0,0"
                              IsVisible="{Binding IsPlannedAmountPresent}">
-                    <Label Text="{x:Static resx:AppResources.PlannedAmount}"/>
+                    <Label Text="{x:Static resx:AppResources.AddCategory_PlannedAmount}"/>
                     <Entry Margin="0,4,0,0"
                            Keyboard="Numeric"
                            Text="{Binding PlannedAmount, Mode=TwoWay}"/>    
                 </StackLayout>
             </StackLayout>
             <Button Grid.Row="2"
-                    Text="{x:Static resx:AppResources.SaveCategory}"
+                    Text="{x:Static resx:AppResources.AddCategory_SaveCategory}"
                     x:Name="AddCategoryButton"
                     Clicked="AddCategoryButton_OnClicked"/>
         </Grid>

--- a/src/Profitocracy.Mobile/Views/Settings/CategoriesSettings/ExpenseCategoriesSettingsPage.xaml
+++ b/src/Profitocracy.Mobile/Views/Settings/CategoriesSettings/ExpenseCategoriesSettingsPage.xaml
@@ -7,7 +7,7 @@
                               xmlns:categories="clr-namespace:Profitocracy.Mobile.Models.Categories"
                               xmlns:abstractions="clr-namespace:Profitocracy.Mobile.Abstractions"
                               x:Class="Profitocracy.Mobile.Views.Settings.CategoriesSettings.ExpenseCategoriesSettingsPage"
-                              Title="{x:Static resx:AppResources.Categories}"
+                              Title="{x:Static resx:AppResources.Pages_Categories}"
                               BackgroundColor="{AppThemeBinding Light={StaticResource LightBackground}, Dark={StaticResource DarkBackground}}"
                               NavigatedTo="UpdateCategoriesList"
                               Loaded="UpdateCategoriesList"

--- a/src/Profitocracy.Mobile/Views/Settings/CategoriesSettings/ExpenseCategoriesSettingsPage.xaml.cs
+++ b/src/Profitocracy.Mobile/Views/Settings/CategoriesSettings/ExpenseCategoriesSettingsPage.xaml.cs
@@ -45,7 +45,7 @@ public partial class ExpenseCategoriesSettingsPage : BaseContentPage
 
 		if (addPage is null)
 		{
-			throw new Exception(AppResources.ErrorAlert_OpenAddCategoryPage);
+			throw new Exception(AppResources.CommonError_OpenAddCategoryPage);
 		}
 
 		await Navigation.PushModalAsync(addPage);

--- a/src/Profitocracy.Mobile/Views/Settings/LanguageSettings/LanguageSettingsPage.xaml
+++ b/src/Profitocracy.Mobile/Views/Settings/LanguageSettings/LanguageSettingsPage.xaml
@@ -5,7 +5,7 @@
                               xmlns:resx="clr-namespace:Profitocracy.Mobile.Resources.Strings"
                               xmlns:abstractions="clr-namespace:Profitocracy.Mobile.Abstractions"
                               x:Class="Profitocracy.Mobile.Views.Settings.LanguageSettings.LanguageSettingsPage"
-                              Title="{x:Static resx:AppResources.Language}"
+                              Title="{x:Static resx:AppResources.Pages_Language}"
                               Loaded="LanguageSettingsPage_OnLoaded"
                               BackgroundColor="{AppThemeBinding Light={StaticResource LightBackground}, Dark={StaticResource DarkBackground}}">
     <abstractions:BaseContentPage.Content>
@@ -31,7 +31,7 @@
                     </Border.Triggers>
                     <FlexLayout JustifyContent="SpaceBetween">
                         <Label Style="{StaticResource SettingsButtonText}"
-                               Text="{x:Static resx:AppResources.EnglishLanguage}" 
+                               Text="{x:Static resx:AppResources.Languages_English}" 
                                VerticalOptions="Center">
                             <Label.Triggers>
                                 <DataTrigger TargetType="Label"
@@ -68,7 +68,7 @@
                     </Border.Triggers>
                     <FlexLayout JustifyContent="SpaceBetween">
                         <Label Style="{StaticResource SettingsButtonText}"
-                               Text="{x:Static resx:AppResources.RussianLanguage}" 
+                               Text="{x:Static resx:AppResources.Languages_Russian}" 
                                VerticalOptions="Center">
                             <Label.Triggers>
                                 <DataTrigger TargetType="Label"

--- a/src/Profitocracy.Mobile/Views/Settings/LanguageSettings/LanguageSettingsPage.xaml.cs
+++ b/src/Profitocracy.Mobile/Views/Settings/LanguageSettings/LanguageSettingsPage.xaml.cs
@@ -46,8 +46,8 @@ public partial class LanguageSettingsPage : BaseContentPage
         await _viewModel.ChangeLanguage(language);
         
         await DisplayAlert(
-            AppResources.ChangeLanguageAlertTitle, 
-            AppResources.ChangeLanguageAlertMessage,
-            AppResources.ChangeLanguageAlertOk);
+            AppResources.InfoAlert_ChangeLanguage_Title, 
+            AppResources.InfoAlert_ChangeLanguage_Message,
+            AppResources.InfoAlert_ChangeLanguage_Ok);
     }
 }

--- a/src/Profitocracy.Mobile/Views/Settings/SettingsPage.xaml
+++ b/src/Profitocracy.Mobile/Views/Settings/SettingsPage.xaml
@@ -5,12 +5,12 @@
                               xmlns:resx="clr-namespace:Profitocracy.Mobile.Resources.Strings"
                               xmlns:abstractions="clr-namespace:Profitocracy.Mobile.Abstractions"
                               x:Class="Profitocracy.Mobile.Views.Settings.SettingsPage"
-                              Title="{x:Static resx:AppResources.Settings}"
+                              Title="{x:Static resx:AppResources.Pages_Settings}"
                               BackgroundColor="{AppThemeBinding Light={StaticResource LightBackground}, Dark={StaticResource DarkBackground}}">
     <ScrollView Padding="16"
                 VerticalScrollBarVisibility="Never">
         <StackLayout>
-            <Label Text="{x:Static resx:AppResources.Application}"
+            <Label Text="{x:Static resx:AppResources.Settings_Application}"
                    Style="{StaticResource SettingsGroupTitle}"
                    Margin="0,0,0,0"/>
             <Border Style="{StaticResource SettingsButton}"
@@ -20,7 +20,7 @@
                 </Border.GestureRecognizers>
                 <FlexLayout JustifyContent="SpaceBetween">
                     <Label Style="{StaticResource SettingsButtonText}"
-                           Text="{x:Static resx:AppResources.Profiles}" />
+                           Text="{x:Static resx:AppResources.Settings_Profiles}" />
                     <Label Style="{StaticResource SettingsButtonText}"
                            Text=">" />
                 </FlexLayout>
@@ -32,13 +32,13 @@
                 </Border.GestureRecognizers>
                 <FlexLayout JustifyContent="SpaceBetween">
                     <Label Style="{StaticResource SettingsButtonText}"
-                           Text="{x:Static resx:AppResources.Categories}" />
+                           Text="{x:Static resx:AppResources.Settings_Categories}" />
                     <Label Style="{StaticResource SettingsButtonText}"
                            Text=">" />
                 </FlexLayout>
             </Border>
             
-            <Label Text="{x:Static resx:AppResources.General}"
+            <Label Text="{x:Static resx:AppResources.Settings_General}"
                    Style="{StaticResource SettingsGroupTitle}"
                    Margin="0,16,0,0"/>
             <Border Style="{StaticResource SettingsButton}"
@@ -48,7 +48,7 @@
                 </Border.GestureRecognizers>
                 <FlexLayout JustifyContent="SpaceBetween">
                     <Label Style="{StaticResource SettingsButtonText}"
-                           Text="{x:Static resx:AppResources.Theme}" />
+                           Text="{x:Static resx:AppResources.Settings_Theme}" />
                     <Label Style="{StaticResource SettingsButtonText}"
                            Text=">" />
                 </FlexLayout>
@@ -60,7 +60,7 @@
                 </Border.GestureRecognizers>
                 <FlexLayout JustifyContent="SpaceBetween">
                     <Label Style="{StaticResource SettingsButtonText}"
-                           Text="{x:Static resx:AppResources.Language}" />
+                           Text="{x:Static resx:AppResources.Settings_Language}" />
                     <Label Style="{StaticResource SettingsButtonText}"
                            Text=">" />
                 </FlexLayout>

--- a/src/Profitocracy.Mobile/Views/Settings/ThemeSettings/ThemeSettingsPage.xaml
+++ b/src/Profitocracy.Mobile/Views/Settings/ThemeSettings/ThemeSettingsPage.xaml
@@ -5,7 +5,7 @@
                               xmlns:resx="clr-namespace:Profitocracy.Mobile.Resources.Strings"
                               xmlns:abstractions="clr-namespace:Profitocracy.Mobile.Abstractions"
                               x:Class="Profitocracy.Mobile.Views.Settings.ThemeSettings.ThemeSettingsPage"
-                              Title="{x:Static resx:AppResources.Theme}"
+                              Title="{x:Static resx:AppResources.Pages_Theme}"
                               Loaded="ThemeSettingsPage_OnLoaded"
                               BackgroundColor="{AppThemeBinding Light={StaticResource LightBackground}, Dark={StaticResource DarkBackground}}">
     <abstractions:BaseContentPage.Content>
@@ -31,7 +31,7 @@
                     </Border.Triggers>
                     <FlexLayout JustifyContent="SpaceBetween">
                         <Label Style="{StaticResource SettingsButtonText}"
-                               Text="{x:Static resx:AppResources.LightThemeText}" 
+                               Text="{x:Static resx:AppResources.ThemeSettings_LightTheme}" 
                                VerticalOptions="Center">
                             <Label.Triggers>
                                 <DataTrigger TargetType="Label"
@@ -68,7 +68,7 @@
                     </Border.Triggers>
                     <FlexLayout JustifyContent="SpaceBetween">
                         <Label Style="{StaticResource SettingsButtonText}"
-                               Text="{x:Static resx:AppResources.DarkThemeText}" 
+                               Text="{x:Static resx:AppResources.ThemeSettings_Dark}" 
                                VerticalOptions="Center">
                             <Label.Triggers>
                                 <DataTrigger TargetType="Label"
@@ -104,7 +104,7 @@
                     </Border.Triggers>
                     <FlexLayout JustifyContent="SpaceBetween">
                         <Label Style="{StaticResource SettingsButtonText}"
-                               Text="{x:Static resx:AppResources.SystemThemeText}" 
+                               Text="{x:Static resx:AppResources.ThemeSettings_System}" 
                                VerticalOptions="Center">
                             <Label.Triggers>
                                 <DataTrigger TargetType="Label"

--- a/src/Profitocracy.Mobile/Views/Setup/SetupPage.xaml
+++ b/src/Profitocracy.Mobile/Views/Setup/SetupPage.xaml
@@ -19,18 +19,18 @@
             <FlexLayout Grid.Row="0"
                         JustifyContent="SpaceBetween">
                 <Label Style="{StaticResource PageTitle}"
-                       Text="{x:Static resx:AppResources.CreateFirstProfile}"/>
+                       Text="{x:Static resx:AppResources.Setup_FirstProfile}"/>
             </FlexLayout>
             <StackLayout Margin="0,32,0,0"
                          Grid.Row="1">
                 <StackLayout>
-                    <Label Text="{x:Static resx:AppResources.ProfileName}"/>
+                    <Label Text="{x:Static resx:AppResources.Setup_ProfileName}"/>
                     <Entry Margin="0,4,0,0"
                            Text="{Binding Name, Mode=TwoWay}" />
                 </StackLayout>
             
                 <StackLayout Margin="0,16,0,0">
-                    <Label Text="{x:Static resx:AppResources.InitialBalance}"/>
+                    <Label Text="{x:Static resx:AppResources.Setup_InitialBalance}"/>
                     <Entry Margin="0,4,0,0"
                            Keyboard="Numeric"
                            Text="{Binding InitialBalance, Mode=TwoWay}"/>
@@ -38,7 +38,7 @@
             </StackLayout>
             
             <Button Grid.Row="2"
-                    Text="{x:Static resx:AppResources.GoToExpenses}" 
+                    Text="{x:Static resx:AppResources.Setup_GoToExpenses}" 
                     Clicked="Button_OnClicked"/>
         </Grid>
     </abstractions:BaseContentPage.Content>

--- a/src/Profitocracy.Mobile/Views/Transactions/AddTransactionPage.xaml
+++ b/src/Profitocracy.Mobile/Views/Transactions/AddTransactionPage.xaml
@@ -14,7 +14,7 @@
             <FlexLayout Grid.Row="0"
                         JustifyContent="SpaceBetween">
                 <Label Style="{StaticResource PageTitle}"
-                       Text="{x:Static resx:AppResources.AddNewTransaction}"/>    
+                       Text="{x:Static resx:AppResources.Pages_NewTransaction}"/>    
                 <Border Style="{StaticResource CloseButton}"
                         VerticalOptions="End"
                         x:Name="CloseButton">
@@ -29,7 +29,7 @@
                   Margin="0,32,0,0"
                   ColumnDefinitions="*,16,*">
                 <Button  Grid.Column="0"
-                        Text="{x:Static resx:AppResources.Expense}"
+                        Text="{x:Static resx:AppResources.AddTransaction_Expense}"
                         x:Name="ExpenseButton"
                         Clicked="ExpenseButton_OnClicked">
                     <Button.Style>
@@ -55,7 +55,7 @@
                     </Button.Style>
                 </Button>
                 <Button Grid.Column="2" 
-                        Text="{x:Static resx:AppResources.Income}"
+                        Text="{x:Static resx:AppResources.AddTransaction_Income}"
                         x:Name="IncomeButton"
                         Clicked="IncomeButton_OnClicked">
                     <Button.Style>
@@ -86,20 +86,20 @@
                 <StackLayout>
                     <StackLayout IsVisible="{Binding IsIncome}">
                         <StackLayout Margin="0,16,0,0">
-                            <Label Text="{x:Static resx:AppResources.Amount}"/>
+                            <Label Text="{x:Static resx:AppResources.AddTransaction_Amount}"/>
                             <Entry Margin="0,4,0,0"
                                    Keyboard="Numeric"
                                    Text="{Binding Amount, Mode=TwoWay}"/>
                         </StackLayout>
                 
                         <StackLayout Margin="0,16,0,0">
-                            <Label Text="{x:Static resx:AppResources.Description}"/>
+                            <Label Text="{x:Static resx:AppResources.AddTransaction_Description}"/>
                             <Entry Margin="0,4,0,0"
                                    Text="{Binding Description, Mode=TwoWay}"/>
                         </StackLayout>
                 
                         <StackLayout Margin="0,16,0,0">
-                            <Label Text="{x:Static resx:AppResources.Date}"/>
+                            <Label Text="{x:Static resx:AppResources.AddTransaction_Date}"/>
                             <DatePicker Margin="0,4,0,0"
                                         Date="{Binding Timestamp, Mode=TwoWay}"/>
                         </StackLayout>
@@ -107,7 +107,7 @@
                     <StackLayout IsVisible="{Binding IsExpense}">
                         <Grid ColumnDefinitions="*,16,*,16,*">
                             <Button Grid.Column="0"
-                                    Text="{x:Static resx:AppResources.Main}"
+                                    Text="{x:Static resx:AppResources.AddTransaction_Main}"
                                     x:Name="MainTypeButton"
                                     Clicked="MainTypeButton_OnClicked">
                                 <Button.Style>
@@ -133,7 +133,7 @@
                                 </Button.Style>
                             </Button>
                             <Button Grid.Column="2"
-                                    Text="{x:Static resx:AppResources.Secondary}"
+                                    Text="{x:Static resx:AppResources.AddTransaction_Secondary}"
                                     x:Name="SecondaryTypeButton"
                                     Clicked="SecondaryTypeButton_OnClicked">
                                 <Button.Style>
@@ -159,7 +159,7 @@
                                 </Button.Style>
                             </Button>
                             <Button Grid.Column="4"
-                                    Text="{x:Static resx:AppResources.Saved}"
+                                    Text="{x:Static resx:AppResources.AddTransaction_Saved}"
                                     x:Name="SavedTypeButton"
                                     Clicked="SavedTypeButton_OnClicked">
                                 <Button.Style>
@@ -187,7 +187,7 @@
                         </Grid>
                     
                         <StackLayout Margin="0,16,0,0">
-                            <Label Text="{x:Static resx:AppResources.Category}"/>
+                            <Label Text="{x:Static resx:AppResources.AddTransaction_Category}"/>
                             <Picker Margin="0,4,0,0"
                                     x:Name="CategoryPicker"
                                     ItemDisplayBinding="{Binding Name}"
@@ -195,20 +195,20 @@
                         </StackLayout>
                     
                         <StackLayout Margin="0,16,0,0">
-                            <Label Text="{x:Static resx:AppResources.Amount}"/>
+                            <Label Text="{x:Static resx:AppResources.AddTransaction_Amount}"/>
                             <Entry Margin="0,4,0,0"
                                    Keyboard="Numeric"
                                    Text="{Binding Amount, Mode=TwoWay}"/>
                         </StackLayout>
                     
                         <StackLayout Margin="0,16,0,0">
-                            <Label Text="{x:Static resx:AppResources.Description}"/>
+                            <Label Text="{x:Static resx:AppResources.AddTransaction_Description}"/>
                             <Entry Margin="0,4,0,0"
                                    Text="{Binding Description, Mode=TwoWay}"/>
                         </StackLayout>
                     
                         <StackLayout Margin="0,16,0,0">
-                            <Label Text="{x:Static resx:AppResources.Date}"/>
+                            <Label Text="{x:Static resx:AppResources.AddTransaction_Date}"/>
                             <DatePicker Margin="0,4,0,0"
                                         Date="{Binding Timestamp, Mode=TwoWay}"/>
                         </StackLayout>
@@ -216,7 +216,7 @@
                 </StackLayout>
             </ScrollView>
             <Button Grid.Row="3"
-                    Text="{x:Static resx:AppResources.SaveTransaction}"
+                    Text="{x:Static resx:AppResources.AddTransaction_SaveTransaction}"
                     VerticalOptions="End"
                     x:Name="AddTransactionButton"
                     Clicked="AddTransactionButton_OnClicked"/>

--- a/src/Profitocracy.Mobile/Views/Transactions/FilteredTransactionsPage.xaml
+++ b/src/Profitocracy.Mobile/Views/Transactions/FilteredTransactionsPage.xaml
@@ -17,7 +17,7 @@
                         JustifyContent="SpaceBetween"
                         Padding="16">
                 <Label Style="{StaticResource PageTitle}"
-                       Text="{x:Static resx:AppResources.Transactions}"/>    
+                       Text="{x:Static resx:AppResources.Pages_Transactions}"/>    
                 <Border Style="{StaticResource CloseButton}"
                         VerticalOptions="End"
                         x:Name="CloseButton">

--- a/src/Profitocracy.Mobile/Views/Transactions/TransactionsPage.xaml
+++ b/src/Profitocracy.Mobile/Views/Transactions/TransactionsPage.xaml
@@ -6,7 +6,7 @@
                               xmlns:transactions="clr-namespace:Profitocracy.Mobile.Models.Transactions"
                               xmlns:abstractions="clr-namespace:Profitocracy.Mobile.Abstractions"
                               x:Class="Profitocracy.Mobile.Views.Transactions.TransactionsPage"
-                              Title="{x:Static resx:AppResources.Transactions}"
+                              Title="{x:Static resx:AppResources.Pages_Transactions}"
                               BackgroundColor="{AppThemeBinding Light={StaticResource LightBackground}, Dark={StaticResource DarkBackground}}"
                               NavigatedTo="TransactionsPage_NavigatedTo">
     <Grid>
@@ -26,7 +26,7 @@
             <StackLayout>
                 <Label Style="{StaticResource DateRangeTitle}"
                        Margin="0, 8, 0,0"
-                       Text="{x:Static resx:AppResources.DateRange}"/>
+                       Text="{x:Static resx:AppResources.Transactions_DateRange}"/>
                 <Grid Margin="0, 8, 0, 0">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*"/>

--- a/src/Profitocracy.Mobile/Views/Transactions/TransactionsPage.xaml.cs
+++ b/src/Profitocracy.Mobile/Views/Transactions/TransactionsPage.xaml.cs
@@ -35,7 +35,7 @@ public partial class TransactionsPage : BaseContentPage
 
 			if (addPage is null)
 			{
-				throw new Exception(AppResources.ErrorAlert_OpenAddTransactionPage);
+				throw new Exception(AppResources.CommonError_OpenAddTransactionPage);
 			}
 		
 			await Navigation.PushModalAsync(addPage);
@@ -48,14 +48,14 @@ public partial class TransactionsPage : BaseContentPage
 		{
 			if (sender is not SwipeItemView swipeItem)
 			{
-				throw new Exception(AppResources.ErrorAlert_InternalErrorTryAgain);
+				throw new Exception(AppResources.CommonError_InternalErrorTryAgain);
 			}
 
 			var transaction = swipeItem.BindingContext as TransactionModel;
 
 			if (transaction?.Id is null)
 			{
-				throw new Exception(AppResources.ErrorAlert_FindTransactionToDelete);
+				throw new Exception(AppResources.CommonError_FindTransactionToDelete);
 			}
 		
 			await _viewModel.DeleteTransaction((Guid)transaction.Id);


### PR DESCRIPTION
- Added calculation of an amount for tomorrow. Also renamed `TodayFromInitial` and `TodayFromActual` to `TodayBalance` and `TomorrowBalance` respectively. That's because today amount calculated from initial balance is useless;
- Improved localization strings by grouping them by the usage places. For example `Home_Balance` or `AddTransaction_Amount`;
- Performed some refactoring in `NumberUtils` type;
- Improved code style in `HomePageViewModel`  type.